### PR TITLE
Add consistency parameters to `bfb`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -126,6 +126,10 @@ pub struct Args {
     #[clap(long)]
     pub shards: Option<usize>,
 
+    /// Write consistency factor to use for collection creation
+    #[clap(long, default_value_t = 1)]
+    pub write_consistency_factor: usize,
+
     /// timeout for requests in seconds
     #[clap(long)]
     pub timeout: Option<usize>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -23,7 +23,7 @@ pub struct Args {
     /// Source of data to upload - fbin file. Random if not specified
     #[clap(long)]
     pub fbin: Option<String>,
-    
+
     #[clap(short, long, default_value_t = 100_000)]
     pub num_vectors: usize,
 
@@ -137,6 +137,10 @@ pub struct Args {
     #[clap(long)]
     pub write_ordering: Option<WriteOrdering>,
 
+    /// Read consistency parameter to use for all read requests
+    #[clap(long)]
+    pub read_consistency: Option<ReadConsistency>,
+
     /// timeout for requests in seconds
     #[clap(long)]
     pub timeout: Option<usize>,
@@ -204,6 +208,110 @@ impl From<WriteOrdering> for qdrant::WriteOrderingType {
             WriteOrdering::Weak => Self::Weak,
             WriteOrdering::Medium => Self::Medium,
             WriteOrdering::Strong => Self::Strong,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum ReadConsistency {
+    Type(ReadConsistencyType),
+    Factor(u64),
+}
+
+impl fmt::Display for ReadConsistency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Type(consistency) => consistency.fmt(f),
+            Self::Factor(factor) => factor.fmt(f),
+        }
+    }
+}
+
+impl str::FromStr for ReadConsistency {
+    type Err = anyhow::Error;
+
+    fn from_str(str: &str) -> Result<Self, Self::Err> {
+        if let Ok(consistency) = str.parse() {
+            return Ok(Self::Type(consistency));
+        }
+
+        if let Ok(factor) = str.parse() {
+            return Ok(Self::Factor(factor));
+        }
+
+        Err(anyhow::format_err!(
+            "invalid ReadConsistency value {str}, \
+             valid values are All, Majority, Quorum or a positive integer number"
+        ))
+    }
+}
+
+impl From<ReadConsistency> for qdrant::ReadConsistency {
+    fn from(consistency: ReadConsistency) -> Self {
+        let consistency = match consistency {
+            ReadConsistency::Type(consistency) => consistency.into(),
+            ReadConsistency::Factor(factor) => qdrant::read_consistency::Value::Factor(factor),
+        };
+
+        qdrant::ReadConsistency {
+            value: consistency.into(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum ReadConsistencyType {
+    All,
+    Majority,
+    Quorum,
+}
+
+impl fmt::Display for ReadConsistencyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str = match self {
+            Self::All => "All",
+            Self::Majority => "Majority",
+            Self::Quorum => "Quorum",
+        };
+
+        str.fmt(f)
+    }
+}
+
+impl str::FromStr for ReadConsistencyType {
+    type Err = anyhow::Error;
+
+    fn from_str(str: &str) -> Result<Self, Self::Err> {
+        match str {
+            "All" => Ok(Self::All),
+            "Majority" => Ok(Self::Majority),
+            "Quorum" => Ok(Self::Quorum),
+            _ => Err(anyhow::format_err!(
+                "invalid ReadConsistencyType value {str}, \
+                 valid values are All, Majority or Quorum"
+            )),
+        }
+    }
+}
+
+impl From<ReadConsistencyType> for qdrant::read_consistency::Value {
+    fn from(consistency: ReadConsistencyType) -> Self {
+        qdrant::read_consistency::Value::Type(consistency.into())
+    }
+}
+
+impl From<ReadConsistencyType> for i32 {
+    fn from(consistency: ReadConsistencyType) -> Self {
+        qdrant::ReadConsistencyType::from(consistency) as _
+    }
+}
+
+impl From<ReadConsistencyType> for qdrant::ReadConsistencyType {
+    fn from(consistency: ReadConsistencyType) -> Self {
+        match consistency {
+            ReadConsistencyType::All => qdrant::ReadConsistencyType::All,
+            ReadConsistencyType::Majority => qdrant::ReadConsistencyType::Majority,
+            ReadConsistencyType::Quorum => qdrant::ReadConsistencyType::Quorum,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
             }),
             on_disk_payload: Some(args.on_disk_payload),
             replication_factor: Some(args.replication_factor as u32),
+            write_consistency_factor: Some(args.write_consistency_factor as u32),
             shard_number: args.shards.map(|x| x as u32),
             quantization_config: match args.quantization {
                 Some(quantization) => match quantization {

--- a/src/search.rs
+++ b/src/search.rs
@@ -68,7 +68,7 @@ impl SearchProcessor {
                 offset: None,
                 vector_name,
                 with_vectors: None,
-                read_consistency: None,
+                read_consistency: self.args.read_consistency.map(Into::into),
             })
             .await?;
         let elapsed = start.elapsed().as_secs_f64();

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -96,17 +96,19 @@ impl UpsertProcessor {
             return Ok(());
         }
 
+        let ordering = self.args.write_ordering.map(Into::into);
+
         let res = if self.args.wait_on_upsert {
             self.clients
                 .choose(&mut rng)
                 .unwrap()
-                .upsert_points_blocking(&self.args.collection_name, points, None)
+                .upsert_points_blocking(&self.args.collection_name, points, ordering.clone())
                 .await?
         } else {
             self.clients
                 .choose(&mut rng)
                 .unwrap()
-                .upsert_points(&self.args.collection_name, points, None)
+                .upsert_points(&self.args.collection_name, points, ordering.clone())
                 .await?
         };
 
@@ -119,7 +121,7 @@ impl UpsertProcessor {
                         &self.args.collection_name,
                         &batch_ids.into(),
                         random_payload(self.args.keywords),
-                        None,
+                        ordering,
                     )
                     .await?;
             } else {
@@ -130,7 +132,7 @@ impl UpsertProcessor {
                         &self.args.collection_name,
                         &batch_ids.into(),
                         random_payload(self.args.keywords),
-                        None,
+                        ordering,
                     )
                     .await?;
             }


### PR DESCRIPTION
Add `write_consistency_factor`, `write_ordering` and `read_consistency` parameters to `bfb`.

The main motivation was to add `write_consistency_factor`, because it's just mildly annoying to test a collection with `write_consistency_factor > 1` currently.

And once I've added the `write_consistency_factor`, I've figured, I'd also add `write_ordering` (I kinda had a need to run `bfb` with non-standard `write_ordering` once or twice) and `read_consistency` (didn't have a need for it yet, but wanted to add to have _all_ consistency parameters).