### PR TITLE
Add flag to ignore search errors and keep going

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -3,14 +3,12 @@ use std::{fmt, str};
 use clap::Parser;
 use qdrant_client::qdrant;
 
-
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
 pub enum QuantizationArg {
     #[default]
     None,
-    Scalar
+    Scalar,
 }
-
 
 /// Big F*cking Benchmark tool for stress-testing Qdrant
 #[derive(Parser, Debug, Clone)]
@@ -112,7 +110,7 @@ pub struct Args {
     /// Use separate request to set payload on just upserted points
     #[clap(long, default_value_t = false)]
     pub set_payload: bool,
-    
+
     /// `hnsw_ef` parameter used during search
     #[clap(long)]
     pub search_hnsw_ef: Option<usize>,
@@ -144,7 +142,7 @@ pub struct Args {
     #[clap(long)]
     pub read_consistency: Option<ReadConsistency>,
 
-    /// timeout for requests in seconds
+    /// Timeout for requests in seconds
     #[clap(long)]
     pub timeout: Option<usize>,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -148,6 +148,10 @@ pub struct Args {
     #[clap(long)]
     pub timeout: Option<usize>,
 
+    /// Keep going on search error
+    #[clap(long, default_value_t = false)]
+    pub ignore_errors: bool,
+
     #[clap(long)]
     pub quantization: Option<QuantizationArg>,
 

--- a/src/fbin_reader.rs
+++ b/src/fbin_reader.rs
@@ -1,7 +1,7 @@
+use memmap2::{Mmap, MmapOptions};
 use std::fs::OpenOptions;
 use std::mem::transmute;
 use std::path::Path;
-use memmap2::{Mmap, MmapOptions};
 
 pub struct FBinReader {
     pub num_vectors: i32,
@@ -10,7 +10,6 @@ pub struct FBinReader {
     pub header_size: usize,
     mmap: Mmap,
 }
-
 
 impl FBinReader {
     pub fn new(path: &Path) -> Self {
@@ -49,7 +48,6 @@ impl FBinReader {
         arr
     }
 }
-
 
 impl Iterator for FBinReader {
     type Item = Vec<f32>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,10 +286,16 @@ async fn search(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
 
     let mut search_stream = futures::stream::iter(query_stream).buffer_unordered(args.parallel);
     while let Some(result) = search_stream.next().await {
-        if !args.ignore_errors {
-            result?;
-        } else if let Err(err) = result {
+        // Continue with no error
+        let err = match result {
+            Ok(()) => continue,
+            Err(err) => err,
+        };
+
+        if args.ignore_errors {
             progress_bar.println(format!("Error: {}", err));
+        } else {
+            return Err(err);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,11 @@ async fn search(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
 
     let mut search_stream = futures::stream::iter(query_stream).buffer_unordered(args.parallel);
     while let Some(result) = search_stream.next().await {
-        result?;
+        if !args.ignore_errors {
+            result?;
+        } else if let Err(err) = result {
+            progress_bar.println(format!("Error: {}", err));
+        }
     }
 
     if stopped.load(Ordering::Relaxed) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,9 +3,9 @@ use crate::{random_filter, random_vector, Args};
 use indicatif::ProgressBar;
 use qdrant_client::client::QdrantClient;
 use qdrant_client::qdrant::{QuantizationSearchParams, SearchParams, SearchPoints};
+use rand::prelude::SliceRandom;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
-use rand::prelude::SliceRandom;
 
 pub struct SearchProcessor {
     args: Args,

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -1,17 +1,16 @@
+use crate::fbin_reader::FBinReader;
 use crate::{random_payload, random_vector, Args};
 use anyhow::Error;
 use indicatif::ProgressBar;
 use qdrant_client::client::QdrantClient;
 use qdrant_client::qdrant::point_id::PointIdOptions;
 use qdrant_client::qdrant::{PointId, PointStruct, Vectors};
+use rand::prelude::SliceRandom;
 use rand::Rng;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use rand::prelude::SliceRandom;
-use crate::fbin_reader::FBinReader;
-
 
 pub struct UpsertProcessor {
     args: Args,
@@ -20,7 +19,6 @@ pub struct UpsertProcessor {
     progress_bar: Arc<ProgressBar>,
     reader: Option<FBinReader>,
 }
-
 
 impl UpsertProcessor {
     pub fn new(


### PR DESCRIPTION
Add the `--ignore-errors` flag to keep going even if search errors occur. This is very useful for stress testing and not abort on the first error.

When this mode is enabled, errors are logged.

<details>
<summary>For example:</summary>

```bash
$ bfb -b100 -p300 -n100000 --search --search-limit 1000 --timeout 3 --ignore-errors
-- snip --
Slow search: 0.639095185
Slow search: 0.639518422
Slow search: 0.640349058
Slow search: 0.640918055
Slow search: 0.642641507
Slow search: 0.643620963
Slow search: 0.644410739
Slow search: 0.645363454
Slow search: 0.641542732
Slow search: 0.735792474
Slow search: 0.736037763
Slow search: 0.736883859
Slow search: 0.737807076
Slow search: 0.738676712
Slow search: 0.739570617
Slow search: 0.740381644
Slow search: 0.741472679
Slow search: 0.742079426
Slow search: 0.742487714
Slow search: 0.742953451
Slow search: 0.743898457
Slow search: 0.744516114
Slow search: 0.834763165
Slow search: 0.835725621
Slow search: 0.83591194
Slow search: 0.836649407
Slow search: 0.837491273
Slow search: 0.838459139
Slow search: 0.839047836
Slow search: 0.839725053
Slow search: 0.840071791
Slow search: 0.840392359
Slow search: 0.840973048
Slow search: 0.841659364
Slow search: 0.842237001
Slow search: 0.842962808
Slow search: 0.843330096
Slow search: 0.843796755
Slow search: 0.934003566
Slow search: 0.934992591
Slow search: 0.93516571
Slow search: 0.935881367
Slow search: 0.936666503
Slow search: 0.937369301
Slow search: 0.938165617
Slow search: 0.939033173
Slow search: 0.93958954
Slow search: 0.942272607
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Error: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
Slow search: 0.396503652
Slow search: 0.39672955
Slow search: 0.398201955
Slow search: 0.398384223
Slow search: 0.489064792
Slow search: 0.489289261
Slow search: 0.490460195
Slow search: 0.49171013
 [00:00:04] ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ [20,836.8469/s] 666/100000 (eta:0s)
```

</details>