### PR TITLE
Support for scroll requests

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -66,6 +66,14 @@ pub struct Args {
     #[clap(long, default_value_t = 10)]
     pub search_limit: usize,
 
+    /// Perform scroll
+    #[clap(long, default_value_t = false)]
+    pub scroll: bool,
+
+    /// Scroll limit
+    #[clap(long)]
+    pub scroll_limit: Option<usize>,
+
     #[clap(long, default_value = "benchmark")]
     pub collection_name: String,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,7 +345,9 @@ async fn scroll(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
     let query_stream = (0..args.num_vectors)
         .take_while(|_| !stopped.load(Ordering::Relaxed))
         .map(|n| {
-            let future = scroller.scroll(n, &progress_bar);
+            // use request number as offset to simulate scroll
+            let offset = n as u64;
+            let future = scroller.scroll(offset, &progress_bar);
             progress_bar.inc(1);
             future
         });

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -27,7 +27,7 @@ impl ScrollProcessor {
 
     pub async fn scroll(
         &self,
-        _req_id: usize,
+        offset: u64,
         progress_bar: &ProgressBar,
     ) -> Result<(), anyhow::Error> {
         if self.stopped.load(std::sync::atomic::Ordering::Relaxed) {
@@ -47,7 +47,7 @@ impl ScrollProcessor {
                 filter: query_filter,
                 limit: self.args.scroll_limit.map(|v| v as u32),
                 with_payload: Some(self.args.search_with_payload.into()),
-                offset: None,
+                offset: Some(offset.into()),
                 with_vectors: None,
                 read_consistency: self.args.read_consistency.map(Into::into),
             })

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -1,0 +1,65 @@
+use crate::{random_filter, Args};
+use indicatif::ProgressBar;
+use qdrant_client::client::QdrantClient;
+use qdrant_client::qdrant::ScrollPoints;
+use rand::prelude::SliceRandom;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+
+pub struct ScrollProcessor {
+    args: Args,
+    stopped: Arc<AtomicBool>,
+    clients: Vec<QdrantClient>,
+    pub server_timings: Mutex<Vec<f64>>,
+    pub full_timings: Mutex<Vec<f64>>,
+}
+
+impl ScrollProcessor {
+    pub fn new(args: Args, stopped: Arc<AtomicBool>, clients: Vec<QdrantClient>) -> Self {
+        ScrollProcessor {
+            args,
+            stopped,
+            clients,
+            server_timings: Mutex::new(Vec::new()),
+            full_timings: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub async fn scroll(
+        &self,
+        _req_id: usize,
+        progress_bar: &ProgressBar,
+    ) -> Result<(), anyhow::Error> {
+        if self.stopped.load(std::sync::atomic::Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        let query_filter = random_filter(self.args.keywords);
+
+        let start = std::time::Instant::now();
+
+        let res = self
+            .clients
+            .choose(&mut rand::thread_rng())
+            .unwrap()
+            .scroll(&ScrollPoints {
+                collection_name: self.args.collection_name.to_string(),
+                filter: query_filter,
+                limit: self.args.scroll_limit.map(|v| v as u32),
+                with_payload: Some(self.args.search_with_payload.into()),
+                offset: None,
+                with_vectors: None,
+                read_consistency: self.args.read_consistency.map(Into::into),
+            })
+            .await?;
+        let elapsed = start.elapsed().as_secs_f64();
+
+        self.full_timings.lock().unwrap().push(elapsed);
+
+        if res.time > self.args.timing_threshold {
+            progress_bar.println(format!("Slow scroll: {:?}", res.time));
+        }
+        self.server_timings.lock().unwrap().push(res.time);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Basic support for performing scroll requests.

The implementation does **not** try to unify search and scroll under a new query processor abstraction to keep things simple.