### PR TITLE
fix: fbin reader offset calculation

### DIFF
--- a/src/fbin_reader.rs
+++ b/src/fbin_reader.rs
@@ -42,7 +42,8 @@ impl FBinReader {
 
     pub fn read_vector(&self, idx: usize) -> &[f32] {
         let vector_size = self.dim as usize;
-        let vector_offset = self.header_size + idx * vector_size;
+        let float_size: usize = std::mem::size_of::<f32>();
+        let vector_offset = self.header_size + idx * vector_size * float_size;
         let vector_raw = &self.mmap[vector_offset..vector_offset + vector_size];
         let arr: &[f32] = unsafe { transmute(vector_raw) };
         arr


### PR DESCRIPTION
Should fix a simple yet major bug in fbin reader of `bfb`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
