### PR TITLE
sparse vectors support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,8 +893,7 @@ dependencies = [
 [[package]]
 name = "qdrant-client"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337c9a836a26e90a171fe8eb4c57e8d0a4e65a23cbac76685960df36c227081e"
+source = "git+https://github.com/qdrant/rust-client.git?branch=dev#9462cc9e05f86b122cb6409bfc6ce78fe23d538c"
 dependencies = [
  "anyhow",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ ctrlc = "3.4.1"
 futures = "0.3.29"
 indicatif = "0.17.7"
 memmap2 = "0.9.0"
-qdrant-client = "1.6.0"
+qdrant-client = { git = "https://github.com/qdrant/rust-client.git", branch = "dev" }
 rand = "0.8.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -221,6 +221,10 @@ pub struct Args {
     /// Skip un-indexed segments during search
     #[clap(long)]
     pub indexed_only: Option<bool>,
+
+    /// Whether to use sparse vectors
+    #[clap(long)]
+    pub sparse_vectors: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -40,7 +40,7 @@ pub struct Args {
     #[clap(short, long)]
     pub max_id: Option<usize>,
 
-    /// Number of dimensions in each vector
+    /// Number of dimensions in each dense vector or max dimension for sparse vectors
     #[clap(short, long, default_value_t = 128)]
     pub dim: usize,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -223,8 +223,12 @@ pub struct Args {
     pub indexed_only: Option<bool>,
 
     /// Whether to use sparse vectors
-    #[clap(long, default_value_t = false)]
-    pub sparse_vectors: bool,
+    #[clap(long)]
+    pub sparse_vectors: Option<f64>,
+
+    /// Number of named vectors per point
+    #[clap(long, default_value_t = 1)]
+    pub sparse_vectors_per_point: usize,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -223,8 +223,8 @@ pub struct Args {
     pub indexed_only: Option<bool>,
 
     /// Whether to use sparse vectors
-    #[clap(long)]
-    pub sparse_vectors: Option<bool>,
+    #[clap(long, default_value_t = false)]
+    pub sparse_vectors: bool,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -116,8 +116,8 @@ pub struct Args {
     pub on_disk_payload: bool,
 
     /// On disk index
-    #[clap(long, default_value_t = false)]
-    pub on_disk_index: bool,
+    #[clap(long)]
+    pub on_disk_index: Option<bool>,
 
     /// On disk vectors
     #[clap(long)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -115,9 +115,9 @@ pub struct Args {
     #[clap(long, default_value_t = false)]
     pub on_disk_payload: bool,
 
-    /// On disk hnsw
+    /// On disk index
     #[clap(long, default_value_t = false)]
-    pub on_disk_hnsw: bool,
+    pub on_disk_index: bool,
 
     /// On disk vectors
     #[clap(long)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -113,23 +113,20 @@ pub fn random_filter(
 }
 
 pub fn random_vector(args: &Args) -> Vector {
-    if args.sparse_vectors {
-        random_sparse_vector(args.dim).into()
-    } else {
-        random_dense_vector(args.dim).into()
-    }
+    random_dense_vector(args.dim).into()
 }
 
 /// Generate random sparse vector with random size and random values.
 /// - `max_size` - maximum size of vector
-pub fn random_sparse_vector(max_size: usize) -> Vec<(u32, f32)> {
+/// - `sparsity` - how many non-zero values should be in vector
+pub fn random_sparse_vector(max_size: usize, sparsity: f64) -> Vec<(u32, f32)> {
     let mut rng = rand::thread_rng();
     let size = rng.gen_range(1..max_size);
     // (index, value)
     let mut pairs = Vec::with_capacity(size);
     for i in 1..=size {
         // probability of skipping a dimension to make the vectors sparse
-        let skip = rng.gen_bool(0.1);
+        let skip = !rng.gen_bool(sparsity);
         if skip {
             continue;
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,9 @@
+use crate::args::Args;
 use core::option::Option;
 use core::option::Option::{None, Some};
 use qdrant_client::client::{Payload, QdrantClient};
 use qdrant_client::qdrant::r#match::MatchValue;
-use qdrant_client::qdrant::{FieldCondition, Filter, Match, Range};
+use qdrant_client::qdrant::{FieldCondition, Filter, Match, Range, Vector};
 use rand::prelude::SliceRandom;
 use rand::Rng;
 
@@ -111,7 +112,26 @@ pub fn random_filter(
     have_any.then_some(filter)
 }
 
-pub fn random_vector(dim: usize) -> Vec<f32> {
+pub fn random_vector(args: &Args) -> Vector {
+    if args.sparse_vectors == Some(true) {
+        random_sparse_vector(args.dim).into()
+    } else {
+        random_dense_vector(args.dim).into()
+    }
+}
+
+pub fn random_sparse_vector(max_size: usize) -> Vec<(u32, f32)> {
+    let mut rng = rand::thread_rng();
+    let size = rng.gen_range(1..max_size);
+    // (index, value)
+    let mut pairs = Vec::with_capacity(size);
+    for i in 1..=size {
+        pairs.push((i as u32, rng.gen_range(-1.0..1.0) as f32));
+    }
+    pairs
+}
+
+pub fn random_dense_vector(dim: usize) -> Vec<f32> {
     let mut rng = rand::thread_rng();
     (0..dim).map(|_| rng.gen_range(-1.0..1.0)).collect()
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -113,7 +113,7 @@ pub fn random_filter(
 }
 
 pub fn random_vector(args: &Args) -> Vector {
-    if args.sparse_vectors == Some(true) {
+    if args.sparse_vectors {
         random_sparse_vector(args.dim).into()
     } else {
         random_dense_vector(args.dim).into()

--- a/src/common.rs
+++ b/src/common.rs
@@ -120,13 +120,21 @@ pub fn random_vector(args: &Args) -> Vector {
     }
 }
 
+/// Generate random sparse vector with random size and random values.
+/// - `max_size` - maximum size of vector
 pub fn random_sparse_vector(max_size: usize) -> Vec<(u32, f32)> {
     let mut rng = rand::thread_rng();
     let size = rng.gen_range(1..max_size);
     // (index, value)
     let mut pairs = Vec::with_capacity(size);
     for i in 1..=size {
-        pairs.push((i as u32, rng.gen_range(-1.0..1.0) as f32));
+        // probability of skipping a dimension to make the vectors sparse
+        let skip = rng.gen_bool(0.05);
+        if skip {
+            continue;
+        }
+        // Only positive values are generated to make sure to hit the pruning path.
+        pairs.push((i as u32, rng.gen_range(0.0..10.0) as f32));
     }
     pairs
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -129,7 +129,7 @@ pub fn random_sparse_vector(max_size: usize) -> Vec<(u32, f32)> {
     let mut pairs = Vec::with_capacity(size);
     for i in 1..=size {
         // probability of skipping a dimension to make the vectors sparse
-        let skip = rng.gen_bool(0.05);
+        let skip = rng.gen_bool(0.1);
         if skip {
             continue;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                     SparseVectorParams {
                         index: Some(SparseIndexConfig {
                             full_scan_threshold: None,
-                            on_disk: Some(args.on_disk_index),
+                            on_disk: args.on_disk_index,
                         }),
                     },
                 )
@@ -169,7 +169,7 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
             collection_name: args.collection_name.clone(),
             vectors_config,
             hnsw_config: Some(HnswConfigDiff {
-                on_disk: Some(args.on_disk_index),
+                on_disk: args.on_disk_index,
                 m: args.hnsw_m.map(|x| x as u64),
                 ef_construct: args.hnsw_ef_construct.map(|x| x as u64),
                 ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,10 +135,11 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
         Config::ParamsMap(VectorParamsMap { map: params })
     };
 
-    let sparse_vectors_config = if args.sparse_vectors == Some(true) {
+    let sparse_vectors_config = if args.sparse_vectors {
         let params = (0..args.vectors_per_point)
             .map(|idx| (idx.to_string(), SparseVectorParams { index: None }))
             .collect();
+        println!("Sparse vectors params: {:?}", params);
 
         Some(SparseVectorConfig { map: params })
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,12 +135,13 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
         Config::ParamsMap(VectorParamsMap { map: params })
     };
 
+    // TODO enable mix configurations (dense+sparse)
     let vectors_config = if args.sparse_vectors {
+        None
+    } else {
         Some(VectorsConfig {
             config: Some(dense_vector_params),
         })
-    } else {
-        None
     };
 
     let sparse_vectors_config = if args.sparse_vectors {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod upsert;
 
 use crate::args::QuantizationArg;
 use crate::common::{
-    random_filter, random_payload, random_vector, INTEGERS_PAYLOAD_KEY, KEYWORD_PAYLOAD_KEY,
+    random_dense_vector, random_filter, random_payload, INTEGERS_PAYLOAD_KEY, KEYWORD_PAYLOAD_KEY,
 };
 use crate::fbin_reader::FBinReader;
 use crate::search::SearchProcessor;
@@ -23,7 +23,8 @@ use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
     CollectionStatus, CompressionRatio, CreateCollection, Distance, FieldType, HnswConfigDiff,
     OptimizersConfigDiff, ProductQuantization, QuantizationConfig, QuantizationType,
-    ScalarQuantization, VectorParams, VectorParamsMap, VectorsConfig,
+    ScalarQuantization, SparseVectorConfig, SparseVectorParams, VectorParams, VectorParamsMap,
+    VectorsConfig,
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -134,6 +135,16 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
         Config::ParamsMap(VectorParamsMap { map: params })
     };
 
+    let sparse_vectors_config = if args.sparse_vectors == Some(true) {
+        let params = (0..args.vectors_per_point)
+            .map(|idx| (idx.to_string(), SparseVectorParams { index: None }))
+            .collect();
+
+        Some(SparseVectorConfig { map: params })
+    } else {
+        None
+    };
+
     client
         .create_collection(&CreateCollection {
             collection_name: args.collection_name.clone(),
@@ -200,6 +211,7 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                 },
                 None => None,
             },
+            sparse_vectors_config,
             ..Default::default()
         })
         .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,20 +135,15 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
         Config::ParamsMap(VectorParamsMap { map: params })
     };
 
-    // TODO enable mix configurations (dense+sparse)
-    let vectors_config = if args.sparse_vectors {
-        None
-    } else {
-        Some(VectorsConfig {
-            config: Some(dense_vector_params),
-        })
-    };
+    let vectors_config = Some(VectorsConfig {
+        config: Some(dense_vector_params),
+    });
 
-    let sparse_vectors_config = if args.sparse_vectors {
-        let params = (0..args.vectors_per_point)
+    let sparse_vectors_config = if args.sparse_vectors.is_some() {
+        let params = (0..args.sparse_vectors_per_point)
             .map(|idx| {
                 (
-                    idx.to_string(),
+                    format!("{idx}_sparse").to_string(),
                     SparseVectorParams {
                         index: Some(SparseIndexConfig {
                             full_scan_threshold: None,

--- a/src/search.rs
+++ b/src/search.rs
@@ -36,7 +36,7 @@ impl SearchProcessor {
             return Ok(());
         }
 
-        let (query_vector, sparse_indices) = if self.args.sparse_vectors == Some(true) {
+        let (query_vector, sparse_indices) = if self.args.sparse_vectors {
             let sparse_vector: Vector = random_sparse_vector(self.args.dim).into();
             (sparse_vector.data, sparse_vector.indices)
         } else {
@@ -50,7 +50,7 @@ impl SearchProcessor {
 
         let start = std::time::Instant::now();
 
-        let vector_name = if self.args.vectors_per_point > 1 {
+        let vector_name = if self.args.vectors_per_point > 1 || self.args.sparse_vectors {
             Some(random_vector_name(self.args.vectors_per_point))
         } else {
             None

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -1,11 +1,12 @@
-use crate::common::{random_vector, retry_with_clients};
+use crate::common::{random_sparse_vector, random_vector, retry_with_clients};
 use crate::fbin_reader::FBinReader;
 use crate::{random_dense_vector, random_payload, Args};
 use anyhow::Error;
 use indicatif::ProgressBar;
 use qdrant_client::client::QdrantClient;
 use qdrant_client::qdrant::point_id::PointIdOptions;
-use qdrant_client::qdrant::{PointId, PointStruct, PointsSelector, Vectors};
+use qdrant_client::qdrant::vectors::VectorsOptions;
+use qdrant_client::qdrant::{PointId, PointStruct, PointsSelector, Vector, Vectors};
 use rand::Rng;
 use std::cmp::min;
 use std::collections::HashMap;
@@ -71,7 +72,7 @@ impl UpsertProcessor {
 
             let vectors: Vectors = if let Some(reader) = &self.reader {
                 reader.read_vector(idx as usize).to_vec().into()
-            } else if self.args.vectors_per_point > 1 {
+            } else if self.args.vectors_per_point != 1 {
                 let vectors_map: HashMap<_, _> = (0..self.args.vectors_per_point)
                     .map(|i| {
                         let vector_name = format!("{}", i);
@@ -80,14 +81,35 @@ impl UpsertProcessor {
                     })
                     .collect();
                 vectors_map.into()
-            } else if self.args.sparse_vectors {
-                // single sparse vector must be named
-                let vectors_map: HashMap<_, _> = vec![("0".to_string(), random_vector(&self.args))]
-                    .into_iter()
-                    .collect();
-                vectors_map.into()
             } else {
                 random_dense_vector(self.args.dim).into()
+            };
+
+            let vectors: Vectors = if let Some(sparsity) = self.args.sparse_vectors {
+                let mut vectors_map: HashMap<_, _> = Default::default();
+
+                for i in 0..self.args.sparse_vectors_per_point {
+                    let vector_name = format!("{}_sparse", i);
+                    let vector = Vector::from(random_sparse_vector(self.args.dim, sparsity));
+                    vectors_map.insert(vector_name, vector);
+                }
+
+                match vectors.vectors_options {
+                    None => {}
+                    Some(vectors) => match vectors {
+                        VectorsOptions::Vector(vector) => {
+                            vectors_map.insert("".to_string(), vector);
+                        }
+                        VectorsOptions::Vectors(vectors) => {
+                            for (name, vector) in vectors.vectors.into_iter() {
+                                vectors_map.insert(name, vector);
+                            }
+                        }
+                    },
+                }
+                vectors_map.into()
+            } else {
+                vectors
             };
 
             points.push(PointStruct::new(

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -80,12 +80,11 @@ impl UpsertProcessor {
                     })
                     .collect();
                 vectors_map.into()
-            } else if self.args.sparse_vectors == Some(true) {
+            } else if self.args.sparse_vectors {
                 // single sparse vector must be named
-                let vectors_map: HashMap<_, _> =
-                    vec![(format!("{}", i), random_vector(&self.args))]
-                        .into_iter()
-                        .collect();
+                let vectors_map: HashMap<_, _> = vec![("0".to_string(), random_vector(&self.args))]
+                    .into_iter()
+                    .collect();
                 vectors_map.into()
             } else {
                 random_dense_vector(self.args.dim).into()


### PR DESCRIPTION
This PR adds support for sparse vectors.

```bash
cargo run -- -n 10000 --dim 2048 --search --sparse-vectors --on-disk-index

--- Search timings ---
Min search time: 0.000557541
Avg search time: 0.10446536149315065
p95 search time: 0.380973509
p99 search time: 0.412968431
Max search time: 0.475767685
--- Server timings ---
Min search time: 0.000256465
Avg search time: 0.10361921244292235
p95 search time: 0.379839804
p99 search time: 0.411853914
Max search time: 0.474702047
--- RPS ---
Min rps: 21.732467847307905
Avg rps: 37.99061218217272
p95 rps: 67.7935806787728
p99 rps: 100.30751254181632
Max rps: 119.50527106181168

```

result from my busy laptop

## Future work
- load sparse vectors from file (maybe SLADE format as well)