### PR TITLE
Add `--throttle` to allow throttling updates/searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ rand = "0.8.5"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.34.0", features = ["full"] }
+tokio-stream = "0.1.14"
 uuid = { version = "1.6.1", features = ["serde", "v4"] }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Options:
           Number of parallel requests to send [default: 2]
   -b, --batch-size <BATCH_SIZE>
           [default: 100]
-      --throttle <THROTTLE>
+      --throttle <BPS>
           Throttle updates, in batches per second. [default=no throttling]
       --skip-create
           Skip creating a collection

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Options:
           Number of parallel requests to send [default: 2]
   -b, --batch-size <BATCH_SIZE>
           [default: 100]
-      --throttle <BPS>
+  -T, --throttle <BPS>
           Throttle updates, in batches per second. [default=no throttling]
       --skip-create
           Skip creating a collection

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Options:
           Number of parallel requests to send [default: 2]
   -b, --batch-size <BATCH_SIZE>
           [default: 100]
+      --throttle <THROTTLE>
+          Throttle updates, in batches per second. [default=no throttling]
       --skip-create
           Skip creating a collection
       --create-if-missing

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Options:
           [default: 100]
   -T, --throttle <BPS>
           Throttle updates, in batches per second. [default=no throttling]
+      --throttle-search <SPS>
+          Throttle searches, in searches per second. [default=no throttling]
       --skip-create
           Skip creating a collection
       --create-if-missing

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Options:
           Number of worker threads to use [default: 2]
   -p, --parallel <PARALLEL>
           Number of parallel requests to send [default: 2]
-  -b, --batch-size <BATCH_SIZE>
-          [default: 100]
+  -b, --batch-size <POINTS>
+          Batch size for updates, in number of points. [default=100] [default: 100]
   -T, --throttle <BPS>
           Throttle updates, in batches per second. [default=no throttling]
       --throttle-search <SPS>

--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ Options:
           Number of parallel requests to send [default: 2]
   -b, --batch-size <POINTS>
           Batch size for updates, in number of points. [default=100] [default: 100]
-  -T, --throttle <BPS>
-          Throttle updates, in batches per second. [default=no throttling]
-      --throttle-search <SPS>
-          Throttle searches, in searches per second. [default=no throttling]
+  -T, --throttle <RPS>
+          Throttle updates and searches, in batches/searches per second. [default=no throttling]
       --skip-create
           Skip creating a collection
       --create-if-missing

--- a/src/args.rs
+++ b/src/args.rs
@@ -56,13 +56,9 @@ pub struct Args {
     #[clap(short, long, value_name = "POINTS", default_value_t = 100)]
     pub batch_size: usize,
 
-    /// Throttle updates, in batches per second. [default=no throttling]
-    #[clap(long, short = 'T', value_name = "BPS")]
+    /// Throttle updates and searches, in batches/searches per second. [default=no throttling]
+    #[clap(long, short = 'T', value_name = "RPS")]
     pub throttle: Option<f32>,
-
-    /// Throttle searches, in searches per second. [default=no throttling]
-    #[clap(long, value_name = "SPS")]
-    pub throttle_search: Option<f32>,
 
     /// Skip creating a collection
     #[clap(long, default_value_t = false)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -56,7 +56,7 @@ pub struct Args {
     pub batch_size: usize,
 
     /// Throttle updates, in batches per second. [default=no throttling]
-    #[clap(long, value_name = "BPS")]
+    #[clap(long, short = 'T', value_name = "BPS")]
     pub throttle: Option<f32>,
 
     /// Skip creating a collection

--- a/src/args.rs
+++ b/src/args.rs
@@ -55,6 +55,10 @@ pub struct Args {
     #[clap(short, long, default_value_t = 100)]
     pub batch_size: usize,
 
+    /// Throttle updates, in batches per second. [default=no throttling]
+    #[clap(long)]
+    pub throttle: Option<f32>,
+
     /// Skip creating a collection
     #[clap(long, default_value_t = false)]
     pub skip_create: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -52,7 +52,8 @@ pub struct Args {
     #[clap(short, long, default_value_t = 2)]
     pub parallel: usize,
 
-    #[clap(short, long, default_value_t = 100)]
+    /// Batch size for updates, in number of points. [default=100]
+    #[clap(short, long, value_name = "POINTS", default_value_t = 100)]
     pub batch_size: usize,
 
     /// Throttle updates, in batches per second. [default=no throttling]

--- a/src/args.rs
+++ b/src/args.rs
@@ -56,7 +56,7 @@ pub struct Args {
     pub batch_size: usize,
 
     /// Throttle updates, in batches per second. [default=no throttling]
-    #[clap(long)]
+    #[clap(long, value_name = "BPS")]
     pub throttle: Option<f32>,
 
     /// Skip creating a collection

--- a/src/args.rs
+++ b/src/args.rs
@@ -59,6 +59,10 @@ pub struct Args {
     #[clap(long, short = 'T', value_name = "BPS")]
     pub throttle: Option<f32>,
 
+    /// Throttle searches, in searches per second. [default=no throttling]
+    #[clap(long, value_name = "SPS")]
+    pub throttle_search: Option<f32>,
+
     /// Skip creating a collection
     #[clap(long, default_value_t = false)]
     pub skip_create: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,7 +398,7 @@ async fn search(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
             future
         });
 
-    let mut throttler = throttler(args.throttle_search);
+    let mut throttler = throttler(args.throttle);
     let mut search_stream = futures::stream::iter(query_stream).buffer_unordered(args.parallel);
     while let (Some(()), Some(result)) = { join!(throttler.next(), search_stream.next()) } {
         // Continue with no error

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use args::Args;
 use clap::Parser;
 use common::FLOAT_PAYLOAD_KEY;
 use futures::stream::StreamExt;
+use futures::Stream;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use qdrant_client::client::{QdrantClient, QdrantClientConfig};
 use qdrant_client::qdrant::quantization_config::Quantization;
@@ -33,8 +34,9 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::runtime;
-use tokio::time::sleep;
+use tokio::time::{interval, sleep};
+use tokio::{join, runtime};
+use tokio_stream::wrappers::IntervalStream;
 
 fn choose_owned<T>(mut items: Vec<T>) -> T {
     let mut rng = rand::thread_rng();
@@ -321,8 +323,24 @@ async fn upload_data(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
         return Ok(());
     }
 
+    // Stream to throttle or resolve instantly if no throttling is defined
+    let mut throttler: Box<dyn Stream<Item = ()> + Unpin> = match args
+        .throttle
+        // Do not support zero or infinite
+        .filter(|throttle| *throttle != 0.0 && !throttle.is_nan() && !throttle.is_infinite())
+        .map(|throttle| Duration::from_secs_f32(1.0 / throttle))
+        // Do not support durations of zero
+        .filter(|duration| !duration.is_zero())
+    {
+        Some(duration) => {
+            let interval = interval(duration);
+            Box::new(IntervalStream::new(interval).map(|_| ()))
+        }
+        None => Box::new(futures::stream::repeat(())),
+    };
+
     let mut upsert_stream = futures::stream::iter(query_stream).buffer_unordered(args.parallel);
-    while let Some(result) = upsert_stream.next().await {
+    while let (Some(()), Some(result)) = { join!(throttler.next(), upsert_stream.next(),) } {
         result?;
     }
     if stopped.load(Ordering::Relaxed) {


### PR DESCRIPTION
This adds a `--throttle <RPS>` option to allow throttling the number of batches per second during update, or the number of searches per second. Of course, by default no throttling is used.

Here's the help output:
```
  -T, --throttle <BPS>
          Throttle updates, in batches per second. [default=no throttling]
```

To throttle with 100 points (1 batch) per second:
```bash
bfb --throttle 1
```

To throttle with 5 points per second:
```bash
bfb -b 1 --throttle 5
```

Or go even lower to 1 batch per 10 seconds:
```bash
bfb --throttle 0.1
```

Instead of batches per second, we can do 'delay between batches' instead, but I think batches per second is a lot more intuitive.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?