### PR TITLE
feat: Add arg for upsert offset

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -35,8 +35,10 @@ pub struct Args {
     #[clap(long, default_value_t = 1)]
     pub vectors_per_point: usize,
 
-    /// If set, will use vector ids within range [0, max_id)
-    /// To simulate overwriting existing vectors
+    #[clap(short, long, default_value_t = 0)]
+    pub offset: usize,
+
+    /// If set, will randomly upsert/override vector ids within range [offset, max_id)
     #[clap(short, long)]
     pub max_id: Option<usize>,
 

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -54,9 +54,9 @@ impl UpsertProcessor {
 
         for i in 0..min(self.args.batch_size, points_left) {
             let idx = if let Some(max_id) = self.args.max_id {
-                rng.gen_range(0..max_id) as u64
+                rng.gen_range(self.args.offset..max_id) as u64
             } else {
-                batch_id as u64 * self.args.batch_size as u64 + i as u64
+                self.args.offset as u64 + (batch_id as u64 * self.args.batch_size as u64 + i as u64)
             };
 
             let point_id: PointId = PointId {


### PR DESCRIPTION
This will help with tracking upsert performance on existing collections.

```
bfb -n 10 --batch-size 1 --skip-wait-index
# upload 10 points

GET collections/benchmark/points/0
{
  "result": {
    "id": 0,
    "payload": {},
    "vector": [
      0.12631863,
      -0.025870178,
      -0.0820347,
      ...,
}

bfb -n 10 --batch-size 1 --offset 1 --skip-create --skip-wait-index
GET collections/benchmark/points/0
{
  "result": {
    "id": 0,
    "payload": {},
    "vector": [
      0.12631863,
      -0.025870178,
      -0.0820347,
      ...,
}
# remained unaffected
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
