### PR TITLE
Add option for retrying upsert/search requests

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -206,6 +206,14 @@ pub struct Args {
     #[clap(long)]
     pub timeout: Option<usize>,
 
+    /// Number of retries for each URI on error, 0 for no retries
+    #[clap(long = "retry", default_value_t = 0)]
+    pub retries: usize,
+
+    /// Number of seconds between each retry.
+    #[clap(long, default_value_t = 0.0, value_name = "SECONDS")]
+    pub retry_interval: f32,
+
     /// Keep going on search error
     #[clap(long, default_value_t = false)]
     pub ignore_errors: bool,

--- a/src/common.rs
+++ b/src/common.rs
@@ -50,7 +50,6 @@ pub fn random_filter(
     integer_payload: Option<usize>,
     match_any: Option<usize>,
 ) -> Option<Filter> {
-
     let mut filter = Filter {
         should: vec![],
         must: vec![],
@@ -58,15 +57,15 @@ pub fn random_filter(
     };
     let mut have_any = false;
     if let Some(keyword_variants) = keywords {
-
         let condition = if let Some(match_any) = match_any {
             MatchValue::Keywords(RepeatedStrings {
-                strings: (0..match_any).map(|_| random_keyword(keyword_variants)).collect(),
+                strings: (0..match_any)
+                    .map(|_| random_keyword(keyword_variants))
+                    .collect(),
             })
         } else {
             MatchValue::Keyword(random_keyword(keyword_variants))
         };
-
 
         have_any = true;
         filter.must.push(

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 use tokio_stream::StreamExt;
+use tracing::warn;
 
 pub const KEYWORD_PAYLOAD_KEY: &str = "a";
 pub const FLOAT_PAYLOAD_KEY: &str = "b";
@@ -186,8 +187,7 @@ pub async fn retry_with_clients<'a, R, T: std::future::Future<Output = anyhow::R
         let is_last = attempt >= args.retries;
         if !is_last {
             if let Err(err) = &res {
-                // TODO: with to logging crate once merged
-                eprintln!("Request failed at attempt {}: {err}", attempt + 1);
+                warn!("Request failed at attempt {}: {err}", attempt + 1);
             }
 
             tokio::time::sleep(Duration::from_secs_f32(args.retry_interval.max(0.0))).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,7 +317,7 @@ async fn upload_data(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
     let query_stream = (0..num_batches)
         .take_while(|_| !stopped.load(Ordering::Relaxed))
         .map(|n| {
-            let future = upserter.upsert(n);
+            let future = upserter.upsert(n, args);
             sent_bar_arc.inc(args.batch_size as u64);
             future
         });
@@ -404,7 +404,7 @@ async fn search(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
     let query_stream = (0..args.num_vectors)
         .take_while(|_| !stopped.load(Ordering::Relaxed))
         .map(|n| {
-            let future = searcher.search(n, &progress_bar);
+            let future = searcher.search(n, args, &progress_bar);
             progress_bar.inc(1);
             future
         });

--- a/src/search.rs
+++ b/src/search.rs
@@ -60,6 +60,7 @@ impl SearchProcessor {
     pub async fn search(
         &self,
         _req_id: usize,
+        args: &Args,
         progress_bar: &ProgressBar,
     ) -> Result<(), anyhow::Error> {
         if self.stopped.load(std::sync::atomic::Ordering::Relaxed) {
@@ -117,8 +118,8 @@ impl SearchProcessor {
             sparse_indices,
         };
 
-        let res =
-            retry_with_clients(&self.clients, |client| client.search_points(&request)).await?;
+        let res = retry_with_clients(&self.clients, args, |client| client.search_points(&request))
+            .await?;
 
         let elapsed = start.elapsed().as_secs_f64();
 


### PR DESCRIPTION
Add the `--retry` and `--retry-interval` options to configure retries for failed requests.

If you specify multiple URIs in bfb it'll already retry on each of them automatically. This new flag adds another layer to retry each of them the specified number of times. It is disabled by default.

The Qdrant client internally also retries once for some gRPC responses, but we don't have control over this behavior.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?