### PR TITLE
feat: Log point IDs if error on upsert

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -442,7 +442,7 @@ async fn process<P: Processor>(args: &Args, stopped: Arc<AtomicBool>, processor:
     print_stats(args, &mut full_timings, "request time", true);
     let mut server_timings = processor.server_timings();
     println!("--- Server timings ---");
-    print_stats(args, &mut server_timings, "request time", true);
+    print_stats(args, &mut server_timings, "server time", true);
     let mut rps = processor.rps();
     println!("--- RPS ---");
     print_stats(args, &mut rps, "rps", false);

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -32,9 +32,8 @@ fn log_points(points: Vec<PointStruct>) -> impl FnOnce(Error) -> Error {
             }
         }
         tracing::warn!(
-            "Failed while upserting. point_ids={:?} error={}",
+            "Failed while upserting. point_ids={:?} error={e}",
             point_ids.join(", "),
-            e
         );
         e
     }

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -21,23 +21,20 @@ use crate::{random_dense_vector, random_payload, Args};
 
 fn log_points(points: Vec<PointStruct>) -> impl FnOnce(Error) -> Error {
     move |e| {
-        let mut nums = Vec::new();
-        let mut uuids = Vec::new();
+        let mut point_ids = Vec::new();
 
         for p in &points {
             if let Some(point_id_option) = p.id.clone().unwrap().point_id_options {
                 match point_id_option {
-                    PointIdOptions::Num(num) => nums.push(num),
-                    PointIdOptions::Uuid(uuid) => uuids.push(uuid),
+                    PointIdOptions::Num(num) => point_ids.push(num.to_string()),
+                    PointIdOptions::Uuid(uuid) => point_ids.push(uuid.to_string()),
                 }
             }
         }
-
-        tracing::warn!("Failed while upserting points. Error: {}", e);
         tracing::warn!(
-            "Failed while upserting. point_ids={:?}, point_uuids={:?}",
-            nums,
-            uuids
+            "Failed while upserting. point_ids={:?} error={}",
+            point_ids.join(", "),
+            e
         );
         e
     }


### PR DESCRIPTION
Helpful for debugging in chaos-testing.

I tested it like this:
1. Run Qdrant with a docker server. `docker compose up -d`
2. Start upsert `RUST_LOG=debug cargo run`
3. Wait for upserts to starts and then kill Qdrant node, `docker compose down` 
4. You'll see entries like this:
```
[2024-06-14T10:13:07Z WARN  bfb::upsert] Failed while upserting points. Error: status: Internal, message: "Failed to connect to http://localhost:6334/: transport error", details: [], metadata: MetadataMap { headers: {} }
[2024-06-14T10:13:07Z WARN  bfb::upsert] Failed while upserting. point_ids=[18100, 18101, 18102, 18103, 18104, 18105, 18106, 18107, 18108, 18109, 18110, 18111, 18112, 18113, 18114, 18115, 18116, 18117, 18118, 18119, 18120, 18121, 18122, 18123, 18124, 18125, 18126, 18127, 18128, 18129, 18130, 18131, 18132, 18133, 18134, 18135, 18136, 18137, 18138, 18139, 18140, 18141, 18142, 18143, 18144, 18145, 18146, 18147, 18148, 18149, 18150, 18151, 18152, 18153, 18154, 18155, 18156, 18157, 18158, 18159, 18160, 18161, 18162, 18163, 18164, 18165, 18166, 18167, 18168, 18169, 18170, 18171, 18172, 18173, 18174, 18175, 18176, 18177, 18178, 18179, 18180, 18181, 18182, 18183, 18184, 18185, 18186, 18187, 18188, 18189, 18190, 18191, 18192, 18193, 18194, 18195, 18196, 18197, 18198, 18199], point_uuids=[]
```