### PR TITLE
Add `--timestamp-payload` CLI option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ name = "bfb"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "ctrlc",
  "env_logger",
@@ -251,6 +252,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "clap"
@@ -923,6 +933,15 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.80"
+chrono = { version = "0.4", default-features = false, features = ["now", "std"] }
 clap = { version = "4.5.1", features = ["derive"] }
 ctrlc = "3.4.2"
 futures = "0.3.30"

--- a/src/args.rs
+++ b/src/args.rs
@@ -166,6 +166,10 @@ pub struct Args {
     #[clap(long)]
     pub int_payloads: Vec<usize>,
 
+    /// Add payload with the current timestamp to all points
+    #[clap(long)]
+    pub timestamp_payload: bool,
+
     /// Use separate request to set payload on just upserted points
     #[clap(long, default_value_t = false)]
     pub set_payload: bool,

--- a/src/common.rs
+++ b/src/common.rs
@@ -55,6 +55,13 @@ pub fn random_payload(args: &Args) -> Payload {
         payload.insert(format!("{}{}", prefix, INTEGERS_PAYLOAD_KEY), value as i64);
     }
 
+    if args.timestamp_payload {
+        payload.insert(
+            "timestamp",
+            chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+        );
+    }
+
     payload
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -58,7 +58,7 @@ pub fn random_payload(args: &Args) -> Payload {
     if args.timestamp_payload {
         payload.insert(
             "timestamp",
-            chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+            chrono::Utc::now().to_rfc3339(),
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,20 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                 .await
                 .unwrap();
         }
+
+        if args.timestamp_payload {
+            client
+                .create_field_index_blocking(
+                    args.collection_name.clone(),
+                    "timestamp",
+                    FieldType::Datetime,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Add `--timestamp-payload` CLI option, that adds payload field with current timestamp to every point. Should be super useful for debugging.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
