### PR TITLE
Add `--shard-key` CLI option

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -288,6 +288,10 @@ pub struct Args {
     /// Default is relative time
     #[clap(long)]
     pub absolute_time: Option<bool>,
+
+    /// Use custom sharding for collection and upsert points to the specified sharding key
+    #[clap(long)]
+    pub shard_key: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -56,10 +56,7 @@ pub fn random_payload(args: &Args) -> Payload {
     }
 
     if args.timestamp_payload {
-        payload.insert(
-            "timestamp",
-            chrono::Utc::now().to_rfc3339(),
-        );
+        payload.insert("timestamp", chrono::Utc::now().to_rfc3339());
     }
 
     payload


### PR DESCRIPTION
Allow `bfb` to create simple collections with custom sharding.

Seems to me that `replication_factor` in `create_shard_key` request doesn't do anything (without a `placement`?), but it's good-enough for my needs already.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
