### PR TITLE
Add tenant support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "qdrant-client"
 version = "1.6.0"
-source = "git+https://github.com/qdrant/rust-client?branch=index_params_improvement#25c9f464b57af39adc67717fc2f6333e22468759"
+source = "git+https://github.com/qdrant/rust-client?branch=dev#a9f99ba6d3c5c1408ecff64408d55fb7b6878f85"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "qdrant-client"
 version = "1.6.0"
-source = "git+https://github.com/qdrant/rust-client?branch=dev#1ac5b10590e68a89ec7750eea04811c3dcd1a3fb"
+source = "git+https://github.com/qdrant/rust-client?branch=index_params_improvement#25c9f464b57af39adc67717fc2f6333e22468759"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,16 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.80"
-chrono = { version = "0.4.38", default-features = false, features = ["now", "std"] }
+chrono = { version = "0.4.38", default-features = false, features = [
+    "now",
+    "std",
+] }
 clap = { version = "4.5.9", features = ["derive"] }
 ctrlc = "3.4.4"
 futures = "0.3.30"
 indicatif = "0.17.8"
 memmap2 = "0.9.4"
-qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "dev" }
+qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "index_params_improvement" }
 rand = "0.8.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ctrlc = "3.4.4"
 futures = "0.3.30"
 indicatif = "0.17.8"
 memmap2 = "0.9.4"
-qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "index_params_improvement" }
+qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "dev" }
 rand = "0.8.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -292,6 +292,10 @@ pub struct Args {
     /// Use custom sharding for collection and upsert points to the specified sharding key
     #[clap(long)]
     pub shard_key: Option<String>,
+
+    /// Use tenant optimization for field index.
+    #[clap(long)]
+    pub tenants: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,10 @@ use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
     CollectionStatus, CompressionRatio, CreateCollectionBuilder, CreateFieldIndexCollectionBuilder,
     CreateShardKeyBuilder, CreateShardKeyRequestBuilder, Distance, FieldType,
-    HnswConfigDiffBuilder, OptimizersConfigDiffBuilder, ProductQuantizationBuilder,
-    QuantizationType, ScalarQuantizationBuilder, ShardingMethod, SparseIndexConfigBuilder,
-    SparseVectorConfig, SparseVectorParamsBuilder, VectorParams, VectorParamsMap, VectorsConfig,
+    HnswConfigDiffBuilder, IntegerIndexParamsBuilder, KeywordIndexParamsBuilder,
+    OptimizersConfigDiffBuilder, ProductQuantizationBuilder, QuantizationType,
+    ScalarQuantizationBuilder, ShardingMethod, SparseIndexConfigBuilder, SparseVectorConfig,
+    SparseVectorParamsBuilder, VectorParams, VectorParamsMap, VectorsConfig,
 };
 use qdrant_client::Qdrant;
 use rand::Rng;
@@ -265,6 +266,10 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         format!("{}{}", payload_prefixes(idx), KEYWORD_PAYLOAD_KEY),
                         FieldType::Keyword,
                     )
+                    .field_index_params(
+                        KeywordIndexParamsBuilder::default()
+                            .is_tenant(args.tenants.unwrap_or_default()),
+                    )
                     .wait(true),
                 )
                 .await
@@ -292,6 +297,10 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         args.collection_name.clone(),
                         format!("{}{}", payload_prefixes(idx), INTEGERS_PAYLOAD_KEY),
                         FieldType::Integer,
+                    )
+                    .field_index_params(
+                        IntegerIndexParamsBuilder::new(true, false)
+                            .is_tenant(args.tenants.unwrap_or_default()),
                     )
                     .wait(true),
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,11 @@ use qdrant_client::qdrant::shard_key::Key;
 use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
     CollectionStatus, CompressionRatio, CreateCollectionBuilder, CreateFieldIndexCollectionBuilder,
-    CreateShardKeyBuilder, CreateShardKeyRequestBuilder, Distance, FieldType,
-    HnswConfigDiffBuilder, IntegerIndexParamsBuilder, KeywordIndexParamsBuilder,
-    OptimizersConfigDiffBuilder, ProductQuantizationBuilder, QuantizationType,
-    ScalarQuantizationBuilder, ShardingMethod, SparseIndexConfigBuilder, SparseVectorConfig,
-    SparseVectorParamsBuilder, VectorParams, VectorParamsMap, VectorsConfig,
+    CreateShardKeyBuilder, CreateShardKeyRequestBuilder, DatetimeIndexParamsBuilder, Distance,
+    FieldType, FloatIndexParamsBuilder, HnswConfigDiffBuilder, IntegerIndexParamsBuilder,
+    KeywordIndexParamsBuilder, OptimizersConfigDiffBuilder, ProductQuantizationBuilder,
+    QuantizationType, ScalarQuantizationBuilder, ShardingMethod, SparseIndexConfigBuilder,
+    SparseVectorConfig, SparseVectorParamsBuilder, VectorParams, VectorParamsMap, VectorsConfig,
 };
 use qdrant_client::Qdrant;
 use rand::Rng;
@@ -284,6 +284,10 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         format!("{}{}", payload_prefixes(idx), FLOAT_PAYLOAD_KEY),
                         FieldType::Float,
                     )
+                    .field_index_params(
+                        FloatIndexParamsBuilder::default()
+                            .is_tenant(args.tenants.unwrap_or_default()),
+                    )
                     .wait(true),
                 )
                 .await
@@ -315,6 +319,10 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         args.collection_name.clone(),
                         "timestamp",
                         FieldType::Datetime,
+                    )
+                    .field_index_params(
+                        DatetimeIndexParamsBuilder::default()
+                            .is_tenant(args.tenants.unwrap_or_default()),
                     )
                     .wait(true),
                 )


### PR DESCRIPTION
Depends on qdrant/rust-client#169

Adds a `--tenants` parameter to configure field indexes for tenants.