### PR TITLE
Log upsert errors

### DIFF
--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -35,7 +35,7 @@ fn log_points(points: Vec<PointStruct>) -> impl FnOnce(QdrantError) -> QdrantErr
             }
         }
         tracing::warn!(
-            "Failed while upserting. point_ids={:?} error={e}",
+            "Failed while upserting. point_ids={:?} error={e:?}",
             point_ids.join(", "),
         );
         e


### PR DESCRIPTION
We found some failure in chaos testing which is logged simply as:

```
[2024-08-30T11:18:03Z WARN  bfb::upsert] Failed while upserting. point_ids="..." error=Error in the response: Unknown error
```

Which doesn't say anything because it converts the struct into minimal string representation.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
