### PR TITLE
Add argument for HNSW payload_m parameter

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -209,6 +209,10 @@ pub struct Args {
     #[clap(long)]
     pub hnsw_m: Option<usize>,
 
+    /// `hnsw_payload_m` parameter used during index
+    #[clap(long)]
+    pub hnsw_payload_m: Option<usize>,
+
     /// `hnsw_ef` parameter used during search
     #[clap(long)]
     pub search_hnsw_ef: Option<usize>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,9 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
     if let Some(m) = args.hnsw_m {
         hnsw_config = hnsw_config.m(m as u64);
     }
+    if let Some(payload_m) = args.hnsw_payload_m {
+        hnsw_config = hnsw_config.payload_m(payload_m as u64);
+    }
     if let Some(ef_construct) = args.hnsw_ef_construct {
         hnsw_config = hnsw_config.ef_construct(ef_construct as u64);
     }


### PR DESCRIPTION
Adds:

```
 --hnsw-payload-m <HNSW_PAYLOAD_M>
     `hnsw_payload_m` parameter used during index
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?