### PR TITLE
Fix not upserting last batch if not a multiple of batch size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,6 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
     client.create_collection(create_collection_builder).await?;
     println!("Created collection: {}", args.collection_name);
 
-
     if stopped.load(Ordering::Relaxed) {
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -450,7 +450,7 @@ async fn upload_data(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
         reader,
     );
 
-    let num_batches = args.num_vectors / args.batch_size;
+    let num_batches = args.num_vectors.div_ceil(args.batch_size);
 
     let query_stream = (0..num_batches)
         .take_while(|_| !stopped.load(Ordering::Relaxed))


### PR DESCRIPTION
If the number of points is not a multiple of the batch size, the last batch would not be sent. This fixes the problem.

The following would not upsert any points before this PR:

```rust
bfb -n 1
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?