### PR TITLE
Add `bool-payloads` option

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -178,6 +178,10 @@ pub struct Args {
     #[clap(long, default_value_t = false)]
     pub uuid_payloads: bool,
 
+    /// Generate true/false payloads
+    #[clap(long, default_value_t = false)]
+    pub bool_payloads: bool,
+
     /// Use geo payloads
     #[clap(long, default_value_t = false)]
     pub geo_payloads: bool,

--- a/src/common.rs
+++ b/src/common.rs
@@ -24,6 +24,7 @@ pub const FLOAT_PAYLOAD_KEY: &str = "b";
 
 pub const INTEGERS_PAYLOAD_KEY: &str = "c";
 pub const UUID_PAYLOAD_KEY: &str = "d";
+pub const BOOL_PAYLOAD_KEY: &str = "e";
 
 pub const GEO_PAYLOAD_KEY: &str = "g";
 
@@ -39,6 +40,8 @@ const GEO_RADIUS_DEG: f64 = 1.0;
 
 const GEO_RADIUS_METERS_MIN: f64 = 1000.0;
 const GEO_RADIUS_METERS_MAX: f64 = 50000.0;
+
+const BOOL_TRUE_RATIO: f64 = 0.7;
 
 #[derive(Debug, Clone)]
 pub struct Timing {
@@ -123,6 +126,13 @@ pub fn random_payload(args: &Args) -> Payload {
         );
     }
 
+    if args.bool_payloads {
+        payload.insert(
+            BOOL_PAYLOAD_KEY,
+            rand::thread_rng().gen_bool(BOOL_TRUE_RATIO),
+        );
+    }
+
     if args.text_payloads {
         let text = random_text(
             args.text_payload_length.unwrap_or(16),
@@ -135,6 +145,7 @@ pub fn random_payload(args: &Args) -> Payload {
     payload
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn random_filter(
     keywords: Option<usize>,
     float_payloads: bool,
@@ -142,6 +153,7 @@ pub fn random_filter(
     uuids: &[String],
     match_any: Option<usize>,
     geo_payloads: bool,
+    bool_payloads: bool,
     text_payloads_vocab: Option<usize>,
 ) -> Option<Filter> {
     let mut filter = Filter {
@@ -259,6 +271,27 @@ pub fn random_filter(
                     radius: radius as f32,
                 }),
 
+                values_count: None,
+                geo_polygon: None,
+                datetime_range: None,
+            }
+            .into(),
+        )
+    }
+
+    if bool_payloads {
+        have_any = true;
+        filter.must.push(
+            FieldCondition {
+                key: BOOL_PAYLOAD_KEY.to_string(),
+                r#match: Some(Match {
+                    match_value: Some(MatchValue::Boolean(
+                        rand::thread_rng().gen_bool(BOOL_TRUE_RATIO),
+                    )),
+                }),
+                range: None,
+                geo_bounding_box: None,
+                geo_radius: None,
                 values_count: None,
                 geo_polygon: None,
                 datetime_range: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,16 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use qdrant_client::config::QdrantConfig;
 use qdrant_client::qdrant::shard_key::Key;
 use qdrant_client::qdrant::vectors_config::Config;
-use qdrant_client::qdrant::{BinaryQuantizationBuilder, CollectionStatus, CompressionRatio, CreateCollectionBuilder, CreateFieldIndexCollectionBuilder, CreateShardKeyBuilder, CreateShardKeyRequestBuilder, DatetimeIndexParamsBuilder, Distance, FieldType, FloatIndexParamsBuilder, HnswConfigDiffBuilder, IntegerIndexParamsBuilder, KeywordIndexParamsBuilder, OptimizersConfigDiffBuilder, ProductQuantizationBuilder, QuantizationType, ScalarQuantizationBuilder, ScrollPointsBuilder, ShardingMethod, SparseIndexConfigBuilder, SparseVectorConfig, SparseVectorParamsBuilder, TextIndexParamsBuilder, TokenizerType, UuidIndexParamsBuilder, VectorParams, VectorParamsMap, VectorsConfig};
+use qdrant_client::qdrant::{
+    BinaryQuantizationBuilder, CollectionStatus, CompressionRatio, CreateCollectionBuilder,
+    CreateFieldIndexCollectionBuilder, CreateShardKeyBuilder, CreateShardKeyRequestBuilder,
+    DatetimeIndexParamsBuilder, Distance, FieldType, FloatIndexParamsBuilder,
+    HnswConfigDiffBuilder, IntegerIndexParamsBuilder, KeywordIndexParamsBuilder,
+    OptimizersConfigDiffBuilder, ProductQuantizationBuilder, QuantizationType,
+    ScalarQuantizationBuilder, ScrollPointsBuilder, ShardingMethod, SparseIndexConfigBuilder,
+    SparseVectorConfig, SparseVectorParamsBuilder, TextIndexParamsBuilder, TokenizerType,
+    UuidIndexParamsBuilder, VectorParams, VectorParamsMap, VectorsConfig,
+};
 use qdrant_client::Qdrant;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -20,7 +29,7 @@ use tokio::time::sleep;
 use tokio::{join, runtime};
 
 use args::Args;
-use common::UUID_PAYLOAD_KEY;
+use common::{BOOL_PAYLOAD_KEY, UUID_PAYLOAD_KEY};
 
 use crate::args::QuantizationArg;
 use crate::common::{
@@ -272,12 +281,12 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         format!("{}{}", payload_prefixes(idx), KEYWORD_PAYLOAD_KEY),
                         FieldType::Keyword,
                     )
-                        .field_index_params(
-                            KeywordIndexParamsBuilder::default()
-                                .on_disk(args.on_disk_payload_index)
-                                .is_tenant(args.tenants.unwrap_or_default()),
-                        )
-                        .wait(true),
+                    .field_index_params(
+                        KeywordIndexParamsBuilder::default()
+                            .on_disk(args.on_disk_payload_index)
+                            .is_tenant(args.tenants.unwrap_or_default()),
+                    )
+                    .wait(true),
                 )
                 .await
                 .unwrap();
@@ -291,12 +300,12 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         format!("{}{}", payload_prefixes(idx), FLOAT_PAYLOAD_KEY),
                         FieldType::Float,
                     )
-                        .field_index_params(
-                            FloatIndexParamsBuilder::default()
-                                .on_disk(args.on_disk_payload_index)
-                                .is_principal(args.tenants.unwrap_or_default()),
-                        )
-                        .wait(true),
+                    .field_index_params(
+                        FloatIndexParamsBuilder::default()
+                            .on_disk(args.on_disk_payload_index)
+                            .is_principal(args.tenants.unwrap_or_default()),
+                    )
+                    .wait(true),
                 )
                 .await
                 .unwrap();
@@ -310,12 +319,12 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         format!("{}{}", payload_prefixes(idx), INTEGERS_PAYLOAD_KEY),
                         FieldType::Integer,
                     )
-                        .field_index_params(
-                            IntegerIndexParamsBuilder::new(true, false)
-                                .on_disk(args.on_disk_payload_index)
-                                .is_principal(args.tenants.unwrap_or_default()),
-                        )
-                        .wait(true),
+                    .field_index_params(
+                        IntegerIndexParamsBuilder::new(true, false)
+                            .on_disk(args.on_disk_payload_index)
+                            .is_principal(args.tenants.unwrap_or_default()),
+                    )
+                    .wait(true),
                 )
                 .await
                 .unwrap();
@@ -329,11 +338,11 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         "timestamp",
                         FieldType::Datetime,
                     )
-                        .field_index_params(
-                            DatetimeIndexParamsBuilder::default()
-                                .is_principal(args.tenants.unwrap_or_default()),
-                        )
-                        .wait(true),
+                    .field_index_params(
+                        DatetimeIndexParamsBuilder::default()
+                            .is_principal(args.tenants.unwrap_or_default()),
+                    )
+                    .wait(true),
                 )
                 .await
                 .unwrap();
@@ -347,12 +356,12 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         UUID_PAYLOAD_KEY,
                         FieldType::Uuid,
                     )
-                        .field_index_params(
-                            UuidIndexParamsBuilder::default()
-                                .is_tenant(args.tenants.unwrap_or_default())
-                                .on_disk(args.on_disk_payload_index),
-                        )
-                        .wait(true),
+                    .field_index_params(
+                        UuidIndexParamsBuilder::default()
+                            .is_tenant(args.tenants.unwrap_or_default())
+                            .on_disk(args.on_disk_payload_index),
+                    )
+                    .wait(true),
                 )
                 .await
                 .unwrap();
@@ -366,10 +375,28 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         GEO_PAYLOAD_KEY,
                         FieldType::Geo,
                     )
-                        .wait(true), // .field_index_params(
-                    //     GeoIndexParamsBuilder::default()
+                    .wait(true), // .field_index_params(
+                                 //     GeoIndexParamsBuilder::default()
+                                 //         .on_disk(args.on_disk_payload_index)
+                                 // )
+                )
+                .await
+                .unwrap();
+        }
+
+        if args.bool_payloads {
+            client
+                .create_field_index(
+                    CreateFieldIndexCollectionBuilder::new(
+                        args.collection_name.clone(),
+                        BOOL_PAYLOAD_KEY,
+                        FieldType::Bool,
+                    )
+                    // .field_index_params(
+                    //     BoolIndexParamsBuilder::default()
                     //         .on_disk(args.on_disk_payload_index)
                     // )
+                    .wait(true),
                 )
                 .await
                 .unwrap();
@@ -383,8 +410,8 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         TEXT_PAYLOAD_KEY,
                         FieldType::Text,
                     )
-                        .field_index_params(TextIndexParamsBuilder::new(TokenizerType::Word))
-                        .wait(true),
+                    .field_index_params(TextIndexParamsBuilder::new(TokenizerType::Word))
+                    .wait(true),
                 )
                 .await
                 .unwrap();
@@ -702,7 +729,7 @@ fn main() {
     ctrlc::set_handler(move || {
         r.store(true, Ordering::SeqCst);
     })
-        .expect("Error setting Ctrl-C handler");
+    .expect("Error setting Ctrl-C handler");
 
     let runtime = runtime::Builder::new_multi_thread()
         .worker_threads(args.threads)

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -63,6 +63,7 @@ impl ScrollProcessor {
             &self.uuids,
             self.args.match_any,
             self.args.geo_payloads,
+            self.args.bool_payloads,
             self.args.text_payloads.then(|| {
                 self.args
                     .text_payload_vocabulary

--- a/src/search.rs
+++ b/src/search.rs
@@ -111,6 +111,7 @@ impl SearchProcessor {
             &self.uuids,
             self.args.match_any,
             self.args.geo_payloads,
+            self.args.bool_payloads,
             self.args.text_payloads.then(|| {
                 self.args
                     .text_payload_vocabulary


### PR DESCRIPTION
Adds the option to include and index and filter boolean fields.

After updating the client for https://github.com/qdrant/qdrant/pull/5571, I'll add the `on_disk` option too