### PR TITLE
chore: migrate to rand 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,14 +208,14 @@ dependencies = [
  "indicatif-log-bridge",
  "memmap2",
  "qdrant-client",
- "rand",
+ "rand 0.9.0",
+ "rand_distr",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tracing",
  "uuid",
- "zipf",
 ]
 
 [[package]]
@@ -595,7 +595,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -887,6 +899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,7 +964,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -969,6 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1071,7 +1090,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1160,7 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1199,8 +1218,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -1210,7 +1240,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -1219,7 +1259,27 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.17",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc3b5afe4c995c44540865b8ca5c52e6a59fa362da96c5d30886930ddc8da1c"
+dependencies = [
+ "num-traits",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -1313,7 +1373,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1714,7 +1774,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1843,7 +1903,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -1861,6 +1921,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2074,13 +2143,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -2095,16 +2182,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[package]]
-name = "zipf"
-version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390e51da0ed8cc3ade001d15fa5ba6f966b99c858fb466ec6b06d1682f1f94dd"
-dependencies = [
- "rand",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ futures = "0.3.31"
 indicatif = "0.17.8"
 memmap2 = "0.9.5"
 qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "dev" }
-rand = "0.8.5"
+rand = "0.9.0"
+rand_distr = "0.5.0"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.40.0", features = ["full"] }
@@ -26,4 +27,3 @@ uuid = { version = "1.10.0", features = ["serde", "v4"] }
 env_logger = "0.11.5"
 indicatif-log-bridge = "0.2.3"
 tracing = { version = "0.1.40", features = ["log"] }
-zipf = "7.0.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,9 +8,10 @@ use qdrant_client::qdrant::{
     FieldCondition, Filter, GeoPoint, GeoRadius, Match, Range, RepeatedStrings, Vector,
 };
 use qdrant_client::{Qdrant, QdrantError};
-use rand::distributions::Distribution;
+use rand::distr::Distribution;
 use rand::prelude::SliceRandom;
-use rand::{thread_rng, Rng};
+use rand::seq::IndexedRandom;
+use rand::{rng, Rng};
 use serde_json::json;
 use std::time::Duration;
 use tokio::time::interval;
@@ -50,12 +51,12 @@ pub struct Timing {
 }
 
 pub fn random_text(num_words: usize, vocab_size: usize) -> String {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
-    let zipf = zipf::ZipfDistribution::new(vocab_size, 1.03).unwrap();
+    let zipf = rand_distr::Zipf::new(f64::from(vocab_size as u32), 1.03).unwrap();
 
     let zipf_distributed_words: Vec<usize> =
-        (0..num_words).map(|_| zipf.sample(&mut rng)).collect();
+        (0..num_words).map(|_| zipf.sample(&mut rng) as usize).collect();
 
     let words: Vec<_> = zipf_distributed_words
         .iter()
@@ -66,16 +67,16 @@ pub fn random_text(num_words: usize, vocab_size: usize) -> String {
 }
 
 pub fn random_keyword(num_variants: usize) -> String {
-    let mut rng = rand::thread_rng();
-    let variant = rng.gen_range(0..num_variants);
+    let mut rng = rand::rng();
+    let variant = rng.random_range(0..num_variants);
     format!("keyword_{}", variant)
 }
 
 fn random_geo_point() -> GeoPoint {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     GeoPoint {
-        lat: BERLIN.lat + rng.gen_range(-GEO_RADIUS_DEG..=GEO_RADIUS_DEG),
-        lon: BERLIN.lon + rng.gen_range(-GEO_RADIUS_DEG..=GEO_RADIUS_DEG),
+        lat: BERLIN.lat + rng.random_range(-GEO_RADIUS_DEG..=GEO_RADIUS_DEG),
+        lon: BERLIN.lon + rng.random_range(-GEO_RADIUS_DEG..=GEO_RADIUS_DEG),
     }
 }
 
@@ -94,13 +95,13 @@ pub fn random_payload(args: &Args) -> Payload {
         let prefix = payload_prefixes(idx);
         payload.insert(
             format!("{}{}", prefix, FLOAT_PAYLOAD_KEY),
-            rand::thread_rng().gen_range(-1.0..1.0),
+            rand::rng().random_range(-1.0..1.0),
         );
     }
 
     for (idx, integer_range) in args.int_payloads.iter().enumerate() {
         let prefix = payload_prefixes(idx);
-        let value = rand::thread_rng().gen_range(0..*integer_range);
+        let value = rand::rng().random_range(0..*integer_range);
         payload.insert(format!("{}{}", prefix, INTEGERS_PAYLOAD_KEY), value as i64);
     }
 
@@ -129,7 +130,7 @@ pub fn random_payload(args: &Args) -> Payload {
     if args.bool_payloads {
         payload.insert(
             BOOL_PAYLOAD_KEY,
-            rand::thread_rng().gen_bool(BOOL_TRUE_RATIO),
+            rand::rng().random_bool(BOOL_TRUE_RATIO),
         );
     }
 
@@ -215,7 +216,7 @@ pub fn random_filter(
     }
     if let Some(integer_range) = integer_payload {
         have_any = true;
-        let rand_int = rand::thread_rng().gen_range(0..integer_range);
+        let rand_int = rand::rng().random_range(0..integer_range);
         filter.must.push(
             FieldCondition {
                 key: INTEGERS_PAYLOAD_KEY.to_string(),
@@ -238,7 +239,7 @@ pub fn random_filter(
 
     if !uuids.is_empty() {
         have_any = true;
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let random = uuids.choose(&mut rng).unwrap();
         filter.must.push(
             FieldCondition {
@@ -259,7 +260,7 @@ pub fn random_filter(
 
     if geo_payloads {
         have_any = true;
-        let radius = rand::thread_rng().gen_range(GEO_RADIUS_METERS_MIN..GEO_RADIUS_METERS_MAX);
+        let radius = rand::rng().random_range(GEO_RADIUS_METERS_MIN..GEO_RADIUS_METERS_MAX);
         filter.must.push(
             FieldCondition {
                 key: GEO_PAYLOAD_KEY.to_string(),
@@ -286,7 +287,7 @@ pub fn random_filter(
                 key: BOOL_PAYLOAD_KEY.to_string(),
                 r#match: Some(Match {
                     match_value: Some(MatchValue::Boolean(
-                        rand::thread_rng().gen_bool(BOOL_TRUE_RATIO),
+                        rand::rng().random_bool(BOOL_TRUE_RATIO),
                     )),
                 }),
                 range: None,
@@ -330,30 +331,30 @@ pub fn random_vector(args: &Args) -> Vector {
 /// - `max_size` - maximum size of vector
 /// - `sparsity` - how many non-zero values should be in vector
 pub fn random_sparse_vector(max_size: usize, sparsity: f64) -> Vec<(u32, f32)> {
-    let mut rng = rand::thread_rng();
-    let size = rng.gen_range(1..max_size);
+    let mut rng = rand::rng();
+    let size = rng.random_range(1..max_size);
     // (index, value)
     let mut pairs = Vec::with_capacity(size);
     for i in 1..=size {
         // probability of skipping a dimension to make the vectors sparse
-        let skip = !rng.gen_bool(sparsity);
+        let skip = !rng.random_bool(sparsity);
         if skip {
             continue;
         }
         // Only positive values are generated to make sure to hit the pruning path.
-        pairs.push((i as u32, rng.gen_range(0.0..10.0) as f32));
+        pairs.push((i as u32, rng.random_range(0.0..10.0) as f32));
     }
     pairs
 }
 
 pub fn random_dense_vector(dim: usize) -> Vec<f32> {
-    let mut rng = rand::thread_rng();
-    (0..dim).map(|_| rng.gen_range(-1.0..1.0)).collect()
+    let mut rng = rand::rng();
+    (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect()
 }
 
 pub fn random_vector_name(max: usize) -> String {
-    let mut rng = rand::thread_rng();
-    format!("{}", rng.gen_range(0..max))
+    let mut rng = rand::rng();
+    format!("{}", rng.random_range(0..max))
 }
 
 pub async fn retry_with_clients<'a, R, T: std::future::Future<Output = Result<R, QdrantError>>>(
@@ -365,7 +366,7 @@ pub async fn retry_with_clients<'a, R, T: std::future::Future<Output = Result<R,
     let mut res = Err(anyhow::anyhow!("No clients"));
 
     for attempt in 0..=args.retries {
-        permutation.shuffle(&mut rand::thread_rng());
+        permutation.shuffle(&mut rand::rng());
         for client_id in &permutation {
             let client = clients.get(*client_id).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,9 +55,9 @@ mod search;
 mod upsert;
 
 fn choose_owned<T>(mut items: Vec<T>) -> T {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     // Get random id
-    let id = rng.gen_range(0..items.len());
+    let id = rng.random_range(0..items.len());
     // Remove item from vector
     items.swap_remove(id)
 }

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -84,14 +84,14 @@ impl UpsertProcessor {
             return Ok(());
         }
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut points = Vec::new();
 
         let mut batch_ids = Vec::new();
 
         for i in 0..min(self.args.batch_size, points_left) {
             let idx = if let Some(max_id) = self.args.max_id {
-                rng.gen_range(self.args.offset..max_id) as u64
+                rng.random_range(self.args.offset..max_id) as u64
             } else {
                 self.args.offset as u64 + (batch_id as u64 * self.args.batch_size as u64 + i as u64)
             };


### PR DESCRIPTION
- Migrates the usage of `rand` to 0.9.0. 
- `zipf` crate [has been deprecated](https://github.com/jonhoo/rust-zipf/pull/12#issuecomment-2645934032) in favor of `rand_distr`'s Zipf. So we swapped as well.