### PR TITLE
Fix sparse query

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -51,7 +51,7 @@ impl SearchProcessor {
         if let Some(sparsity) = self.args.sparse_vectors {
             let sparse_vector_tuples =
                 random_sparse_vector(self.args.sparse_dim.unwrap_or(self.args.dim), sparsity);
-            let (indices, values): (Vec<_>, Vec<_>) = sparse_vector_tuples.iter().cloned().unzip();
+            let (indices, values): (Vec<_>, Vec<_>) = sparse_vector_tuples.into_iter().unzip();
             let sparse_indices = SparseIndices { data: indices };
             let name = format!(
                 "{}_sparse",
@@ -65,12 +65,11 @@ impl SearchProcessor {
 
     fn get_dense_query(&self) -> (Vec<f32>, Option<SparseIndices>, Option<String>) {
         let query_vector = random_dense_vector(self.args.dim);
-        let sparse_indices = None;
         if self.args.vectors_per_point > 1 {
             let name = random_vector_name(self.args.vectors_per_point);
-            (query_vector, sparse_indices, Some(name))
+            (query_vector, None, Some(name))
         } else {
-            (query_vector, sparse_indices, None)
+            (query_vector, None, None)
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,7 +4,6 @@ use crate::{random_dense_vector, random_filter, Args};
 use indicatif::ProgressBar;
 use qdrant_client::qdrant::{
     QuantizationSearchParamsBuilder, SearchParamsBuilder, SearchPointsBuilder, SparseIndices,
-    Vector,
 };
 use qdrant_client::Qdrant;
 use std::sync::atomic::AtomicBool;
@@ -50,16 +49,15 @@ impl SearchProcessor {
 
     fn get_sparse_query(&self) -> (Vec<f32>, Option<SparseIndices>, Option<String>) {
         if let Some(sparsity) = self.args.sparse_vectors {
-            let sparse_vector: Vector =
-                random_sparse_vector(self.args.sparse_dim.unwrap_or(self.args.dim), sparsity)
-                    .into();
-            let query_vector = sparse_vector.data;
-            let sparse_indices = sparse_vector.indices;
+            let sparse_vector_tuples =
+                random_sparse_vector(self.args.sparse_dim.unwrap_or(self.args.dim), sparsity);
+            let (indices, values): (Vec<_>, Vec<_>) = sparse_vector_tuples.iter().cloned().unzip();
+            let sparse_indices = SparseIndices { data: indices };
             let name = format!(
                 "{}_sparse",
                 random_vector_name(self.args.sparse_vectors_per_point)
             );
-            (query_vector, sparse_indices, Some(name))
+            (values, Some(sparse_indices), Some(name))
         } else {
             panic!("No sparse vectors configured")
         }


### PR DESCRIPTION
Fix sparse query generation.

It was generating client side errors because the `values` and `indices` were empty resulting in:

```
Client specified an invalid argument Wrong input: Conversion between sparse and regular vectors failed error.
```

The root cause is that the query generation still used the old vector format which got deprecated a while ago by the following converter in the Rust client.

```rust
impl From<crate::qdrant::vector::Vector> for Vector {
    fn from(vector: crate::qdrant::vector::Vector) -> Self {
        Vector {
            vector: Some(vector),
            // Deprecated
            data: vec![],
            indices: None,
            vectors_count: None,
        }
    }
}
```