### PR TITLE
Enable integer range index

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,7 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         FieldType::Integer,
                     )
                     .field_index_params(
-                        IntegerIndexParamsBuilder::new(true, false)
+                        IntegerIndexParamsBuilder::new(true, true)
                             .on_disk(args.on_disk_payload_index)
                             .is_principal(args.tenants.unwrap_or_default()),
                     )


### PR DESCRIPTION
Enables the complete integer index, including the range index.

`bfb` does not make use of the range index during search.

But since Qdrant itself enables the range index by default, I think it makes sense to do the same here as well.

I'm currently testing the range filter specifically, and so this comes in handy.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?