### PR TITLE
Add argument to enable integer range index

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -184,6 +184,10 @@ pub struct Args {
     #[clap(long, value_parser = parse_number)]
     pub int_payloads: Vec<usize>,
 
+    /// Whether to enable the range index for the integer payloads
+    #[clap(long, default_value_t = false)]
+    pub int_payloads_range: bool,
+
     #[clap(long, default_value_t = false)]
     pub uuid_payloads: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,7 +325,7 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
                         FieldType::Integer,
                     )
                     .field_index_params(
-                        IntegerIndexParamsBuilder::new(true, false)
+                        IntegerIndexParamsBuilder::new(true, args.int_payloads_range)
                             .on_disk(args.on_disk_payload_index)
                             .is_principal(args.tenants.unwrap_or_default()),
                     )


### PR DESCRIPTION
Add `--int-payloads-range` flag to also enable the 'range' index for integers.

While the range index will not be used by bfb itself, it's useful for testing purposes. I've already been wanting this for quite a few times now.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?