### PR TITLE
Add argument to generate array of integers in payload

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use std::{fmt, str};
+use std::{fmt, num::NonZeroUsize, str};
 
 use clap::Parser;
 use qdrant_client::qdrant;
@@ -187,6 +187,10 @@ pub struct Args {
     /// Whether to enable the range index for the integer payloads
     #[clap(long, default_value_t = false)]
     pub int_payloads_range: bool,
+
+    /// Maximum number of integer payloads per point
+    #[clap(long, value_parser = parse_number, default_value_t = NonZeroUsize::new(1).unwrap())]
+    pub max_int_payloads: NonZeroUsize,
 
     #[clap(long, default_value_t = false)]
     pub uuid_payloads: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use std::{fmt, num::NonZeroUsize, str};
+use std::{fmt, str};
 
 use clap::Parser;
 use qdrant_client::qdrant;
@@ -189,8 +189,8 @@ pub struct Args {
     pub int_payloads_range: bool,
 
     /// Maximum number of integer payloads per point
-    #[clap(long, value_parser = parse_number, default_value_t = NonZeroUsize::new(1).unwrap())]
-    pub max_int_payloads: NonZeroUsize,
+    #[clap(long, value_parser = parse_number, default_value_t = 1)]
+    pub max_int_payloads: usize,
 
     #[clap(long, default_value_t = false)]
     pub uuid_payloads: bool,

--- a/src/common.rs
+++ b/src/common.rs
@@ -97,13 +97,12 @@ pub fn random_payload(args: &Args) -> Payload {
     }
 
     for (idx, integer_range) in args.int_payloads.iter().enumerate() {
+        let prefix = payload_prefixes(idx);
         if args.max_int_payloads == 1 {
-            let prefix = payload_prefixes(idx);
             let value = rand::rng().random_range(0..*integer_range);
             payload.insert(format!("{}{}", prefix, INTEGERS_PAYLOAD_KEY), value as i64);
         } else {
             let count = rand::rng().random_range(1..=args.max_int_payloads);
-            let prefix = payload_prefixes(idx);
             let values = (0..count)
                 .map(|_| rand::rng().random_range(0..*integer_range) as i64)
                 .collect::<Vec<_>>();

--- a/src/common.rs
+++ b/src/common.rs
@@ -97,9 +97,18 @@ pub fn random_payload(args: &Args) -> Payload {
     }
 
     for (idx, integer_range) in args.int_payloads.iter().enumerate() {
-        let prefix = payload_prefixes(idx);
-        let value = rand::rng().random_range(0..*integer_range);
-        payload.insert(format!("{}{}", prefix, INTEGERS_PAYLOAD_KEY), value as i64);
+        if args.max_int_payloads.get() == 1 {
+            let prefix = payload_prefixes(idx);
+            let value = rand::rng().random_range(0..*integer_range);
+            payload.insert(format!("{}{}", prefix, INTEGERS_PAYLOAD_KEY), value as i64);
+        } else {
+            let count = rand::rng().random_range(1..=args.max_int_payloads.get());
+            let prefix = payload_prefixes(idx);
+            let values = (0..count)
+                .map(|_| rand::rng().random_range(0..*integer_range) as i64)
+                .collect::<Vec<_>>();
+            payload.insert(format!("{}{}", prefix, INTEGERS_PAYLOAD_KEY), values);
+        }
     }
 
     if args.uuid_payloads {

--- a/src/common.rs
+++ b/src/common.rs
@@ -97,12 +97,12 @@ pub fn random_payload(args: &Args) -> Payload {
     }
 
     for (idx, integer_range) in args.int_payloads.iter().enumerate() {
-        if args.max_int_payloads.get() == 1 {
+        if args.max_int_payloads == 1 {
             let prefix = payload_prefixes(idx);
             let value = rand::rng().random_range(0..*integer_range);
             payload.insert(format!("{}{}", prefix, INTEGERS_PAYLOAD_KEY), value as i64);
         } else {
-            let count = rand::rng().random_range(1..=args.max_int_payloads.get());
+            let count = rand::rng().random_range(1..=args.max_int_payloads);
             let prefix = payload_prefixes(idx);
             let values = (0..count)
                 .map(|_| rand::rng().random_range(0..*integer_range) as i64)


### PR DESCRIPTION
Add `--max-int-payloads` argument for generating an array of integer values in payload.

If setting `--max-int-payloads 5`, bfb will always generate an array of integers where each point has 1 to 5 (inclusive) integers.

With the default of `--max-int-payloads 1` no array will be used.

Kept the interface simple on purpose. We can adjust it later if we need more options.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?