### PR TITLE
Add Datatype and Multivector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Options:
           Whether to use sparse vectors and with how much sparsity
       --sparse-vectors-per-point <SPARSE_VECTORS_PER_POINT>
           Number of named sparse vectors per point [default: 1]
-      --multivector-size <SPARSITY>
+      --multivector-size <MULTIVECTOR_SIZE>
           Whether to set dense vectors as multivectors
       --sparse-dim <SPARSE_DIM>
           Max dimension for sparse vectors (overrides --dim)

--- a/README.md
+++ b/README.md
@@ -11,17 +11,21 @@ Options:
       --fbin <FBIN>
           Source of data to upload - fbin file. Random if not specified
   -n, --num-vectors <NUM_VECTORS>
-          Number of points to upload [default: 100000]
+          Number of points to upload [default: 100_000]
       --vectors-per-point <VECTORS_PER_POINT>
-          Number of named vectors per point [default: 1]
+          Number of named dense vectors per point [default: 1]
+  -o, --offset <OFFSET>
+          [default: 0]
   -m, --max-id <MAX_ID>
-          If set, will use vector ids within range [0, max_id) To simulate overwriting existing vectors
+          If set, will randomly upsert/override vector ids within range [offset, max_id)
   -d, --dim <DIM>
           Number of dimensions in each dense vector or max dimension for sparse vectors [default: 128]
   -t, --threads <THREADS>
           Number of worker threads to use [default: 2]
   -p, --parallel <PARALLEL>
           Number of parallel requests to send [default: 2]
+  -c, --connections <CONNECTIONS>
+          Number of connections to open from the client to the server [default: 1]
   -b, --batch-size <POINTS>
           Batch size for updates, in number of points. [default=100] [default: 100]
   -T, --throttle <RPS>
@@ -37,7 +41,11 @@ Options:
       --search
           Perform search
       --search-exact
-          Search without approximation
+          Perform search without approximation
+      --prefetch <PREFETCH>
+          Prefetch search
+      --scroll
+          Perform scroll
       --search-limit <SEARCH_LIMIT>
           Search limit [default: 10]
       --json <JSON>
@@ -48,6 +56,8 @@ Options:
           Name of the collection to use [default: benchmark]
       --distance <DISTANCE>
           Distance function used for comparing vectors [default: Cosine]
+      --datatype <DATATYPE>
+          Vector datatypes (Uint8, Float16, Float32)
       --mmap-threshold <MMAP_THRESHOLD>
           Store vectors on disk
       --indexing-threshold <INDEXING_THRESHOLD>
@@ -57,6 +67,8 @@ Options:
       --max-segment-size <MAX_SEGMENT_SIZE>
           Do not create segments larger this size (in kilobytes)
       --on-disk-payload
+          On disk payload
+      --on-disk-payload-index
           On disk payload
       --on-disk-index <ON_DISK_INDEX>
           On disk index [possible values: true, false]
@@ -68,18 +80,40 @@ Options:
           Use UUIDs instead of sequential ids
       --skip-field-indices
           Skip field indices creation if payloads are not empty
-      --keywords <KEYWORDS>
+  -k, --keywords <KEYWORDS>
           Use keyword payloads. Defines how many different keywords there are in the payload
-      --float-payloads
-          Use float payloads
+      --float-payloads <FLOAT_PAYLOADS>
+          Use float payloads [possible values: true, false]
+      --match-any <MATCH_ANY>
+          Match any count
       --int-payloads <INT_PAYLOADS>
           Use integer payloads
+      --int-payloads-range
+          Whether to enable the range index for the integer payloads
+      --max-int-payloads <MAX_INT_PAYLOADS>
+          Maximum number of integer payloads per point [default: 1]
+      --uuid-payloads
+
+      --bool-payloads
+          Generate true/false payloads
+      --geo-payloads
+          Use geo payloads
+      --text-payloads
+          generate text-like payloads
+      --text-payload-length <TEXT_PAYLOAD_LENGTH>
+          Length of the text-like payloads
+      --text-payload-vocabulary <TEXT_PAYLOAD_VOCABULARY>
+          Vocabulary size for text-like payloads
+      --timestamp-payload
+          Add payload with the current timestamp to all points
       --set-payload
           Use separate request to set payload on just upserted points
       --hnsw-ef-construct <HNSW_EF_CONSTRUCT>
           `hnsw_ef_construct` parameter used during index
       --hnsw-m <HNSW_M>
           `hnsw_m` parameter used during index
+      --hnsw-payload-m <HNSW_PAYLOAD_M>
+          `hnsw_payload_m` parameter used during index
       --search-hnsw-ef <SEARCH_HNSW_EF>
           `hnsw_ef` parameter used during search
       --search-with-payload
@@ -98,10 +132,14 @@ Options:
           Read consistency parameter to use for all read requests
       --timeout <TIMEOUT>
           Timeout for requests in seconds
+      --retry <RETRIES>
+          Number of retries for each URI on error, 0 for no retries [default: 0]
+      --retry-interval <SECONDS>
+          Number of seconds between each retry [default: 0]
       --ignore-errors
           Keep going on search error
       --quantization <QUANTIZATION>
-          [possible values: none, scalar, product-x4, product-x8, product-x16, product-x32, product-x64]
+          [possible values: none, binary, scalar, product-x4, product-x8, product-x16, product-x32, product-x64]
       --quantization-in-ram <QUANTIZATION_IN_RAM>
           Keep quantized vectors in memory [possible values: true, false]
       --quantization-rescore <QUANTIZATION_RESCORE>
@@ -115,13 +153,35 @@ Options:
       --sparse-vectors <SPARSITY>
           Whether to use sparse vectors and with how much sparsity
       --sparse-vectors-per-point <SPARSE_VECTORS_PER_POINT>
-          Number of named vectors per point [default: 1]
+          Number of named sparse vectors per point [default: 1]
+      --multivector-size <SPARSITY>
+          Whether to set dense vectors as multivectors
       --sparse-dim <SPARSE_DIM>
           Max dimension for sparse vectors (overrides --dim)
+      --jsonl-updates <JSONL_UPDATES>
+          Path to the jsonl file to save update timings TIP: Use `qdrant/mri` to visualize the timings
+      --jsonl-searches <JSONL_SEARCHES>
+          Path to the jsonl file to save search timings TIP: Use `qdrant/mri` to visualize the timings
+      --jsonl-rps <JSONL_RPS>
+          Path to the jsonl file to save rps timings TIP: Use `qdrant/mri` to visualize the timings
+      --absolute-time <ABSOLUTE_TIME>
+          Use timestamp instead of relative time in jsonl Default is relative time [possible values: true, false]
+      --shard-key <SHARD_KEY>
+          Use custom sharding for collection and upsert points to the specified sharding key
+      --tenants <TENANTS>
+          Use tenant optimization for field index [possible values: true, false]
+      --uuid-query <UUID_QUERY>
+          Use a custom UUID as filter when searching
+      --search-quality
+          Bench for search quality / accurracy too
+      --full-scan-threshold <FULL_SCAN_THRESHOLD>
+          Set a custom full-scan threshold
   -h, --help
           Print help
   -V, --version
           Print version
+
+Integers can be suffixed with k/M/G/T/ki/Mi/Gi/Ti, and underscores can be inserted to make them more readable, e.g., `--num-vectors 100k --offset 1_000_000`.
 ```
 
 API KEY:

--- a/src/args.rs
+++ b/src/args.rs
@@ -124,6 +124,10 @@ pub struct Args {
     #[clap(long, default_value = "Cosine")]
     pub distance: String,
 
+    /// Vector datatypes (Uint8, Float16, Float32)
+    #[clap(long)]
+    pub datatype: Option<String>,
+
     /// Store vectors on disk
     #[clap(long, value_parser = parse_number)]
     pub mmap_threshold: Option<usize>,
@@ -313,6 +317,10 @@ pub struct Args {
     /// Number of named sparse vectors per point
     #[clap(long, default_value_t = 1)]
     pub sparse_vectors_per_point: usize,
+
+    /// Whether to set dense vectors as multivectors
+    #[clap(long, value_name = "SPARSITY")]
+    pub multivector_size: Option<usize>,
 
     /// Max dimension for sparse vectors (overrides --dim)
     #[clap(long, value_parser = parse_number)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -319,7 +319,7 @@ pub struct Args {
     pub sparse_vectors_per_point: usize,
 
     /// Whether to set dense vectors as multivectors
-    #[clap(long, value_name = "SPARSITY")]
+    #[clap(long)]
     pub multivector_size: Option<usize>,
 
     /// Max dimension for sparse vectors (overrides --dim)

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,7 +5,7 @@ use core::option::Option::{None, Some};
 use futures::Stream;
 use qdrant_client::qdrant::r#match::MatchValue;
 use qdrant_client::qdrant::{
-    Condition, Filter, GeoPoint, GeoRadius, Range, RepeatedStrings, Vector,
+    Condition, Datatype, Filter, GeoPoint, GeoRadius, Range, RepeatedStrings, Vector,
 };
 use qdrant_client::{Payload, Qdrant, QdrantError};
 use rand::distr::Distribution;
@@ -254,7 +254,19 @@ pub fn random_filter(
 }
 
 pub fn random_vector(args: &Args) -> Vector {
-    random_dense_vector(args.dim).into()
+    let is_uint = args
+        .datatype
+        .as_ref()
+        .map(|x| x == Datatype::Uint8.as_str_name())
+        .unwrap_or(false);
+    if let Some(count) = args.multivector_size {
+        let multivector: Vec<_> = (0..count)
+            .map(|_| random_dense_vector(args.dim, is_uint))
+            .collect();
+        Vector::new_multi(multivector)
+    } else {
+        random_dense_vector(args.dim, is_uint).into()
+    }
 }
 
 /// Generate random sparse vector with random size and random values.
@@ -277,9 +289,13 @@ pub fn random_sparse_vector(max_size: usize, sparsity: f64) -> Vec<(u32, f32)> {
     pairs
 }
 
-pub fn random_dense_vector(dim: usize) -> Vec<f32> {
+pub fn random_dense_vector(dim: usize, is_uint: bool) -> Vec<f32> {
     let mut rng = rand::rng();
-    (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect()
+    if is_uint {
+        (0..dim).map(|_| rng.random_range(0..255) as f32).collect()
+    } else {
+        (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect()
+    }
 }
 
 pub fn random_vector_name(max: usize) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,13 +15,13 @@ use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
     BinaryQuantizationBuilder, BoolIndexParamsBuilder, CollectionStatus, CompressionRatio,
     CreateCollectionBuilder, CreateFieldIndexCollectionBuilder, CreateShardKeyBuilder,
-    CreateShardKeyRequestBuilder, DatetimeIndexParamsBuilder, Distance, FieldType,
+    CreateShardKeyRequestBuilder, Datatype, DatetimeIndexParamsBuilder, Distance, FieldType,
     FloatIndexParamsBuilder, HnswConfigDiffBuilder, IntegerIndexParamsBuilder,
-    KeywordIndexParamsBuilder, OptimizersConfigDiffBuilder, ProductQuantizationBuilder,
-    QuantizationType, ScalarQuantizationBuilder, ScrollPointsBuilder, ShardingMethod,
-    SparseIndexConfigBuilder, SparseVectorConfig, SparseVectorParamsBuilder,
-    TextIndexParamsBuilder, TokenizerType, UuidIndexParamsBuilder, VectorParams, VectorParamsMap,
-    VectorsConfig,
+    KeywordIndexParamsBuilder, MultiVectorComparator, MultiVectorConfigBuilder,
+    OptimizersConfigDiffBuilder, ProductQuantizationBuilder, QuantizationType,
+    ScalarQuantizationBuilder, ScrollPointsBuilder, ShardingMethod, SparseIndexConfigBuilder,
+    SparseVectorConfig, SparseVectorParamsBuilder, TextIndexParamsBuilder, TokenizerType,
+    UuidIndexParamsBuilder, VectorParams, VectorParamsMap, VectorsConfig,
 };
 use qdrant_client::Qdrant;
 use rand::Rng;
@@ -137,6 +137,22 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
         return Ok(());
     }
 
+    let datatype = args
+        .datatype
+        .as_ref()
+        .map(|datatype| match datatype.as_str() {
+            "Uint8" => Datatype::Uint8.into(),
+            "Float16" => Datatype::Float16.into(),
+            "Float32" => Datatype::Float32.into(),
+            _ => {
+                panic!("Unknown vector datatype {}", datatype)
+            }
+        });
+
+    let multivector_config = args.multivector_size.map(|_multivector_size| {
+        MultiVectorConfigBuilder::new(MultiVectorComparator::MaxSim).build()
+    });
+
     let vector_param = VectorParams {
         size: args.dim as u64,
         distance: match args.distance.as_str() {
@@ -149,6 +165,8 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
             }
         },
         on_disk: args.on_disk_vectors,
+        multivector_config,
+        datatype,
         ..Default::default()
     };
 
@@ -168,12 +186,13 @@ async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Result<()
         let params: HashMap<_, _> = (0..args.sparse_vectors_per_point)
             .map(|idx| {
                 let key = format!("{idx}_sparse");
-
+                let mut index_builder = SparseIndexConfigBuilder::default()
+                    .on_disk(args.on_disk_index.unwrap_or_default());
+                if let Some(datatype) = datatype {
+                    index_builder = index_builder.datatype(datatype);
+                }
                 let config = SparseVectorParamsBuilder::default()
-                    .index(
-                        SparseIndexConfigBuilder::default()
-                            .on_disk(args.on_disk_index.unwrap_or_default()),
-                    )
+                    .index(index_builder)
                     .build();
 
                 (key, config)

--- a/src/search.rs
+++ b/src/search.rs
@@ -69,7 +69,7 @@ impl SearchProcessor {
     }
 
     fn get_dense_query(&self) -> (Vec<f32>, Option<SparseIndices>, Option<String>) {
-        let query_vector = random_dense_vector(self.args.dim);
+        let query_vector = random_dense_vector(self.args.dim, false);
         if self.args.vectors_per_point > 1 {
             let name = random_vector_name(self.args.vectors_per_point);
             (query_vector, None, Some(name))

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -20,7 +20,7 @@ use tokio::time::sleep;
 use crate::common::{random_sparse_vector, random_vector, retry_with_clients, Timing};
 use crate::fbin_reader::FBinReader;
 use crate::save_jsonl::save_timings_as_jsonl;
-use crate::{random_dense_vector, random_payload, Args};
+use crate::{random_payload, Args};
 
 fn log_points(points: &[PointStruct]) -> impl FnOnce(QdrantError) -> QdrantError + use<'_> {
     move |e| {
@@ -119,7 +119,7 @@ impl UpsertProcessor {
                     .collect();
                 vectors_map.into()
             } else {
-                random_dense_vector(self.args.dim).into()
+                random_vector(&self.args).into()
             };
 
             let vectors: Vectors = if let Some(sparsity) = self.args.sparse_vectors {


### PR DESCRIPTION
Adds two new options:

1. A vector `datatype` is applied to both dense and sparse vectors. 
Additionally generates valid Uint8 values 0..255.

2. Turn the dense vector configuration into a multivector with `multivector-size`.