### PR TITLE
Fix float+int filter range in search

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -193,8 +193,8 @@ pub fn random_filter(
         filter.must.push(Condition::range(
             float_payload_name(integer_index_pos),
             Range {
-                gt: Some(0.0),
-                gte: None,
+                gt: None,
+                gte: Some(0.0),
                 lt: None,
                 lte: None,
             },
@@ -211,8 +211,8 @@ pub fn random_filter(
         filter.must.push(Condition::range(
             int_payload_name(integer_index_pos),
             Range {
-                gt: Some(rand_int as f64),
-                gte: None,
+                gt: None,
+                gte: Some(rand_int as f64),
                 lt: None,
                 lte: None,
             },


### PR DESCRIPTION
Depends on #73 

Adjusts the range for float/integer filters during search to prevent filters not matching any points.