### PR TITLE
Rust docker 1.87.0 for 2024 edition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
-FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.84.1 AS chef
+FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.87.0 AS chef
 WORKDIR /bfb
 
 FROM chef AS planner


### PR DESCRIPTION
Rust edition 2024 in https://github.com/qdrant/bfb/pull/77 needs at least Rust 1.85.