### PR TITLE
`max-keywords`: customize max number of keywords per point

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -176,6 +176,10 @@ pub struct Args {
     #[clap(long, short = 'k', value_parser = parse_number)]
     pub keywords: Vec<usize>,
 
+    /// Maximum number of keywords per point
+    #[clap(long, value_parser = parse_number, default_value_t = 1)]
+    pub max_keywords: usize,
+
     /// Use float payloads
     #[clap(long)]
     pub float_payloads: Vec<bool>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -85,7 +85,16 @@ pub fn random_payload(args: &Args) -> Payload {
     let mut payload = Payload::new();
 
     for (idx, variants) in args.keywords.iter().enumerate() {
-        payload.insert(keyword_payload_name(idx), random_keyword(*variants));
+        let payload_name = keyword_payload_name(idx);
+        if args.max_keywords == 1 {
+            payload.insert(payload_name, random_keyword(*variants));
+        } else {
+            let count = rand::rng().random_range(1..=args.max_keywords);
+            let values = (0..count)
+                .map(|_| random_keyword(*variants))
+                .collect::<Vec<_>>();
+            payload.insert(payload_name, values);
+        }
     }
 
     for (idx, _) in args.float_payloads.iter().enumerate() {


### PR DESCRIPTION
Adds `--max-keywords` option to specify how many keywords per point (in each keyword field) are upserted. Akin to the existing `--max_int_payloads`.