### PR TITLE
Add --skip-setup flag

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -89,6 +89,7 @@ pub struct Args {
     pub skip_upload: bool,
 
     /// Skip setting up collections.
+    /// Implies --skip-create --skip-upload --skip-wait-index
     #[clap(long, default_value_t = false)]
     pub skip_setup: bool,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -88,6 +88,10 @@ pub struct Args {
     #[clap(long, default_value_t = false)]
     pub skip_upload: bool,
 
+    /// Skip setting up collections.
+    #[clap(long, default_value_t = false)]
+    pub skip_setup: bool,
+
     /// Perform search
     #[clap(long, default_value_t = false)]
     pub search: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -739,15 +739,15 @@ async fn run_benchmark(args: Args, stopped: Arc<AtomicBool>) -> Result<()> {
         println!("Ignoring `exact` flag because `search_quality` is also enabled!");
     }
 
-    if !args.skip_create {
+    if !args.skip_create && !args.skip_setup {
         recreate_collection(&args, stopped.clone()).await?;
     }
 
-    if !args.skip_upload {
+    if !args.skip_upload && !args.skip_setup {
         upload_data(&args, stopped.clone()).await?;
     }
 
-    if !args.skip_wait_index {
+    if !args.skip_wait_index && args.skip_setup {
         println!("Waiting for index to be ready...");
         let wait_time = wait_index(&args, stopped.clone()).await?;
         println!("Index ready in {wait_time} seconds");


### PR DESCRIPTION
Adds a new flag `--skip-setup` that skips any kind of setup (upload, creation, index waiting).
This makes search-only behavior less verbose.
Before we always had to type `--skip-creation --skip-upload --skip-wait-index` to perform a search only request.