### PR TITLE
Use /bfb as the working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,8 +101,11 @@ RUN PKG_CONFIG="/usr/bin/$(xx-info)-pkg-config" \
     && mv "target/$(xx-cargo --print-target-triple)/$PROFILE_DIR/bfb" /bfb/bfb
 
 FROM debian:12-slim AS bfb
+ARG APP=/bfb
 
-COPY --from=builder /bfb/bfb /bfb
+RUN mkdir -p ${APP}
+COPY --from=builder /bfb/bfb ${APP}/bfb
+WORKDIR ${APP}
 
 # USER 1000
 


### PR DESCRIPTION
bfb-upsert and bfb-upload started failing in chaos testing. See [CI run](https://github.com/qdrant/haloperidol-ansible/actions/runs/17124708882/job/48573565852)

This happened because we accidently changed the working directory from `/bfb` to `/` in https://github.com/qdrant/bfb/pull/87. The binary is at `/bfb/bfb`

This PR brings back `/bfb` as the working directory so it remains backward compatible.