### PR TITLE
Fix docker container GLIBC error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} tonistiigi/xx AS xx
 # Utilizing Docker layer caching with `cargo-chef`.
 #
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
-FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.90.0 AS chef
+FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.90.0-bookworm AS chef
 
 
 FROM chef AS planner


### PR DESCRIPTION
Updating to [cargo-chef:latest-rust-1.90.0](https://github.com/qdrant/bfb/pull/90/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L14) broke the image with:

```
docker run -it --rm --network=host qdrant/bfb:dev ./bfb -n 1000 --shards 1 --replication-factor 2
Unable to find image 'qdrant/bfb:dev' locally
dev: Pulling from qdrant/bfb
5c32499ab806: Already exists
8e3a1954ff1b: Pull complete
b46d711e85ef: Pull complete
b4caafd4ad9f: Pull complete
4f4fb700ef54: Pull complete
Digest: sha256:fb93929852eb2080c88e592de579bec601ef5a58edac3ba240ab6249431a4943
Status: Downloaded newer image for qdrant/bfb:dev
./bfb: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./bfb)
./bfb: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./bfb)
```

This is similar to https://github.com/qdrant/qdrant/pull/7334