### PR TITLE
Refactor rand part 1

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -88,19 +88,18 @@ fn estimated_payload_size(args: &Args) -> usize {
         + args.text_payloads as usize
 }
 
-pub fn random_payload(args: &Args) -> Payload {
-    let mut rng = rand::rng();
+pub fn random_payload(rng: &mut impl Rng, args: &Args) -> Payload {
     let payload_size = estimated_payload_size(args);
     let mut payload = Payload::with_capacity(payload_size);
 
     for (idx, variants) in args.keywords.iter().enumerate() {
         let payload_name = keyword_payload_name(idx);
         if args.max_keywords == 1 {
-            payload.insert(payload_name, random_keyword(&mut rng, *variants));
+            payload.insert(payload_name, random_keyword(rng, *variants));
         } else {
             let count = rng.random_range(1..=args.max_keywords);
             let values = (0..count)
-                .map(|_| random_keyword(&mut rng, *variants))
+                .map(|_| random_keyword(rng, *variants))
                 .collect::<Vec<_>>();
             payload.insert(payload_name, values);
         }
@@ -136,7 +135,7 @@ pub fn random_payload(args: &Args) -> Payload {
     }
 
     if args.geo_payloads {
-        let point = random_geo_point(&mut rng);
+        let point = random_geo_point(rng);
 
         payload.insert(
             GEO_PAYLOAD_KEY,
@@ -154,7 +153,7 @@ pub fn random_payload(args: &Args) -> Payload {
 
     if args.text_payloads {
         let text = random_text(
-            &mut rng,
+            rng,
             args.text_payload_length.unwrap_or(16),
             args.text_payload_vocabulary.unwrap_or(DEFAULT_VOCAB_SIZE),
         );

--- a/src/common.rs
+++ b/src/common.rs
@@ -166,6 +166,7 @@ pub fn random_payload(rng: &mut impl Rng, args: &Args) -> Payload {
 
 #[allow(clippy::too_many_arguments)]
 pub fn random_filter(
+    rng: &mut impl Rng,
     keywords: &[usize],
     float_payloads: &[bool],
     integer_payload: &[usize],
@@ -175,7 +176,6 @@ pub fn random_filter(
     bool_payloads: bool,
     text_payloads_vocab: Option<usize>,
 ) -> Option<Filter> {
-    let mut rng = rand::rng();
     let mut filter = Filter {
         should: vec![],
         must: vec![],
@@ -191,11 +191,11 @@ pub fn random_filter(
 
         let condition = if let Some(match_any) = match_any {
             let strings = (0..match_any)
-                .map(|_| random_keyword(&mut rng, keyword_variants))
+                .map(|_| random_keyword(rng, keyword_variants))
                 .collect();
             MatchValue::Keywords(RepeatedStrings { strings })
         } else {
-            MatchValue::Keyword(random_keyword(&mut rng, keyword_variants))
+            MatchValue::Keyword(random_keyword(rng, keyword_variants))
         };
 
         have_any = true;
@@ -240,7 +240,7 @@ pub fn random_filter(
 
     if !uuids.is_empty() {
         have_any = true;
-        let random = uuids.choose(&mut rng).unwrap();
+        let random = uuids.choose(rng).unwrap();
         filter
             .must
             .push(Condition::matches(UUID_PAYLOAD_KEY, random.to_string()))
@@ -252,7 +252,7 @@ pub fn random_filter(
         filter.must.push(Condition::geo_radius(
             GEO_PAYLOAD_KEY,
             GeoRadius {
-                center: Some(random_geo_point(&mut rng)),
+                center: Some(random_geo_point(rng)),
                 radius: radius as f32,
             },
         ))
@@ -270,7 +270,7 @@ pub fn random_filter(
         have_any = true;
         filter.must.push(Condition::matches_text(
             TEXT_PAYLOAD_KEY,
-            random_text(&mut rng, 2, vocab_size),
+            random_text(rng, 2, vocab_size),
         ))
     }
 
@@ -322,8 +322,7 @@ pub fn random_dense_vector(dim: usize, is_uint: bool) -> Vec<f32> {
     }
 }
 
-pub fn random_vector_name(max: usize) -> String {
-    let mut rng = rand::rng();
+pub fn random_vector_name(rng: &mut impl Rng, max: usize) -> String {
     format!("{}", rng.random_range(0..max))
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -277,7 +277,7 @@ pub fn random_filter(
     have_any.then_some(filter)
 }
 
-pub fn random_vector(args: &Args) -> Vector {
+pub fn random_vector(rng: &mut impl Rng, args: &Args) -> Vector {
     let is_uint = args
         .datatype
         .as_ref()
@@ -285,19 +285,18 @@ pub fn random_vector(args: &Args) -> Vector {
         .unwrap_or(false);
     if let Some(count) = args.multivector_size {
         let multivector: Vec<_> = (0..count)
-            .map(|_| random_dense_vector(args.dim, is_uint))
+            .map(|_| random_dense_vector(rng, args.dim, is_uint))
             .collect();
         Vector::new_multi(multivector)
     } else {
-        random_dense_vector(args.dim, is_uint).into()
+        random_dense_vector(rng, args.dim, is_uint).into()
     }
 }
 
 /// Generate random sparse vector with random size and random values.
 /// - `max_size` - maximum size of vector
 /// - `sparsity` - how many non-zero values should be in vector
-pub fn random_sparse_vector(max_size: usize, sparsity: f64) -> Vec<(u32, f32)> {
-    let mut rng = rand::rng();
+pub fn random_sparse_vector(rng: &mut impl Rng, max_size: usize, sparsity: f64) -> Vec<(u32, f32)> {
     let size = rng.random_range(1..max_size);
     // (index, value)
     let mut pairs = Vec::with_capacity(size);
@@ -313,8 +312,7 @@ pub fn random_sparse_vector(max_size: usize, sparsity: f64) -> Vec<(u32, f32)> {
     pairs
 }
 
-pub fn random_dense_vector(dim: usize, is_uint: bool) -> Vec<f32> {
-    let mut rng = rand::rng();
+pub fn random_dense_vector(rng: &mut impl Rng, dim: usize, is_uint: bool) -> Vec<f32> {
     if is_uint {
         (0..dim).map(|_| rng.random_range(0..255) as f32).collect()
     } else {

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,7 +11,7 @@ use qdrant_client::{Payload, Qdrant, QdrantError};
 use rand::distr::Distribution;
 use rand::prelude::SliceRandom;
 use rand::seq::IndexedRandom;
-use rand::{Rng, rng};
+use rand::Rng;
 use serde_json::json;
 use std::time::Duration;
 use tokio::time::interval;
@@ -50,13 +50,11 @@ pub struct Timing {
     pub value: f64,
 }
 
-pub fn random_text(num_words: usize, vocab_size: usize) -> String {
-    let mut rng = rand::rng();
-
+pub fn random_text(rng: &mut impl Rng, num_words: usize, vocab_size: usize) -> String {
     let zipf = rand_distr::Zipf::new(f64::from(vocab_size as u32), 1.03).unwrap();
 
     let zipf_distributed_words: Vec<usize> = (0..num_words)
-        .map(|_| zipf.sample(&mut rng) as usize)
+        .map(|_| zipf.sample(rng) as usize)
         .collect();
 
     let words: Vec<_> = zipf_distributed_words
@@ -67,14 +65,12 @@ pub fn random_text(num_words: usize, vocab_size: usize) -> String {
     words.join(" ")
 }
 
-pub fn random_keyword(num_variants: usize) -> String {
-    let mut rng = rand::rng();
+pub fn random_keyword(rng: &mut impl Rng, num_variants: usize) -> String {
     let variant = rng.random_range(0..num_variants);
     format!("keyword_{variant}")
 }
 
-fn random_geo_point() -> GeoPoint {
-    let mut rng = rand::rng();
+fn random_geo_point(rng: &mut impl Rng,) -> GeoPoint {
     GeoPoint {
         lat: BERLIN.lat + rng.random_range(-GEO_RADIUS_DEG..=GEO_RADIUS_DEG),
         lon: BERLIN.lon + rng.random_range(-GEO_RADIUS_DEG..=GEO_RADIUS_DEG),
@@ -93,24 +89,25 @@ fn estimated_payload_size(args: &Args) -> usize {
 }
 
 pub fn random_payload(args: &Args) -> Payload {
+    let mut rng = rand::rng();
     let payload_size = estimated_payload_size(args);
     let mut payload = Payload::with_capacity(payload_size);
 
     for (idx, variants) in args.keywords.iter().enumerate() {
         let payload_name = keyword_payload_name(idx);
         if args.max_keywords == 1 {
-            payload.insert(payload_name, random_keyword(*variants));
+            payload.insert(payload_name, random_keyword(&mut rng, *variants));
         } else {
-            let count = rand::rng().random_range(1..=args.max_keywords);
+            let count = rng.random_range(1..=args.max_keywords);
             let values = (0..count)
-                .map(|_| random_keyword(*variants))
+                .map(|_| random_keyword(&mut rng, *variants))
                 .collect::<Vec<_>>();
             payload.insert(payload_name, values);
         }
     }
 
     for (idx, _) in args.float_payloads.iter().enumerate() {
-        let value = rand::rng().random_range(-1.0..1.0);
+        let value = rng.random_range(-1.0..1.0);
         payload.insert(float_payload_name(idx), value);
     }
 
@@ -118,12 +115,12 @@ pub fn random_payload(args: &Args) -> Payload {
         let payload_name = int_payload_name(idx);
 
         if args.max_int_payloads == 1 {
-            let value = rand::rng().random_range(0..*integer_range);
+            let value = rng.random_range(0..*integer_range);
             payload.insert(payload_name, value as i64);
         } else {
-            let count = rand::rng().random_range(1..=args.max_int_payloads);
+            let count = rng.random_range(1..=args.max_int_payloads);
             let values = (0..count)
-                .map(|_| rand::rng().random_range(0..*integer_range) as i64)
+                .map(|_| rng.random_range(0..*integer_range) as i64)
                 .collect::<Vec<_>>();
             payload.insert(payload_name, values);
         }
@@ -139,7 +136,7 @@ pub fn random_payload(args: &Args) -> Payload {
     }
 
     if args.geo_payloads {
-        let point = random_geo_point();
+        let point = random_geo_point(&mut rng);
 
         payload.insert(
             GEO_PAYLOAD_KEY,
@@ -152,11 +149,12 @@ pub fn random_payload(args: &Args) -> Payload {
     }
 
     if args.bool_payloads {
-        payload.insert(BOOL_PAYLOAD_KEY, rand::rng().random_bool(BOOL_TRUE_RATIO));
+        payload.insert(BOOL_PAYLOAD_KEY, rng.random_bool(BOOL_TRUE_RATIO));
     }
 
     if args.text_payloads {
         let text = random_text(
+            &mut rng,
             args.text_payload_length.unwrap_or(16),
             args.text_payload_vocabulary.unwrap_or(DEFAULT_VOCAB_SIZE),
         );
@@ -178,6 +176,7 @@ pub fn random_filter(
     bool_payloads: bool,
     text_payloads_vocab: Option<usize>,
 ) -> Option<Filter> {
+    let mut rng = rand::rng();
     let mut filter = Filter {
         should: vec![],
         must: vec![],
@@ -188,16 +187,16 @@ pub fn random_filter(
 
     if !keywords.is_empty() {
         // Pick a random keyword payload filter.
-        let keyword_index_pos = rand::rng().random_range(0..keywords.len());
+        let keyword_index_pos = rng.random_range(0..keywords.len());
         let keyword_variants = keywords[keyword_index_pos];
 
         let condition = if let Some(match_any) = match_any {
             let strings = (0..match_any)
-                .map(|_| random_keyword(keyword_variants))
+                .map(|_| random_keyword(&mut rng, keyword_variants))
                 .collect();
             MatchValue::Keywords(RepeatedStrings { strings })
         } else {
-            MatchValue::Keyword(random_keyword(keyword_variants))
+            MatchValue::Keyword(random_keyword(&mut rng, keyword_variants))
         };
 
         have_any = true;
@@ -210,7 +209,7 @@ pub fn random_filter(
     if !float_payloads.is_empty() {
         have_any = true;
 
-        let integer_index_pos = rand::rng().random_range(0..float_payloads.len());
+        let integer_index_pos = rng.random_range(0..float_payloads.len());
         filter.must.push(Condition::range(
             float_payload_name(integer_index_pos),
             Range {
@@ -225,10 +224,10 @@ pub fn random_filter(
     if !integer_payload.is_empty() {
         have_any = true;
 
-        let integer_index_pos = rand::rng().random_range(0..integer_payload.len());
+        let integer_index_pos = rng.random_range(0..integer_payload.len());
         let int_range = integer_payload[integer_index_pos];
 
-        let rand_int = rand::rng().random_range(0..int_range);
+        let rand_int = rng.random_range(0..int_range);
         filter.must.push(Condition::range(
             int_payload_name(integer_index_pos),
             Range {
@@ -242,7 +241,6 @@ pub fn random_filter(
 
     if !uuids.is_empty() {
         have_any = true;
-        let mut rng = rng();
         let random = uuids.choose(&mut rng).unwrap();
         filter
             .must
@@ -251,11 +249,11 @@ pub fn random_filter(
 
     if geo_payloads {
         have_any = true;
-        let radius = rand::rng().random_range(GEO_RADIUS_METERS_MIN..GEO_RADIUS_METERS_MAX);
+        let radius = rng.random_range(GEO_RADIUS_METERS_MIN..GEO_RADIUS_METERS_MAX);
         filter.must.push(Condition::geo_radius(
             GEO_PAYLOAD_KEY,
             GeoRadius {
-                center: Some(random_geo_point()),
+                center: Some(random_geo_point(&mut rng)),
                 radius: radius as f32,
             },
         ))
@@ -265,7 +263,7 @@ pub fn random_filter(
         have_any = true;
         filter.must.push(Condition::matches(
             BOOL_PAYLOAD_KEY,
-            rand::rng().random_bool(BOOL_TRUE_RATIO),
+            rng.random_bool(BOOL_TRUE_RATIO),
         ))
     }
 
@@ -273,7 +271,7 @@ pub fn random_filter(
         have_any = true;
         filter.must.push(Condition::matches_text(
             TEXT_PAYLOAD_KEY,
-            random_text(2, vocab_size),
+            random_text(&mut rng, 2, vocab_size),
         ))
     }
 
@@ -335,11 +333,12 @@ pub async fn retry_with_clients<'a, R, T: std::future::Future<Output = Result<R,
     args: &Args,
     mut call: impl FnMut(&'a Qdrant) -> T,
 ) -> anyhow::Result<R> {
+    let mut rng = rand::rng();
     let mut permutation = (0..clients.len()).collect::<Vec<_>>();
     let mut previous_err: Option<Error> = None;
 
     for attempt in 0..=args.retries {
-        permutation.shuffle(&mut rand::rng());
+        permutation.shuffle(&mut rng);
         for client_id in &permutation {
             let client = clients.get(*client_id).unwrap();
 

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -55,8 +55,9 @@ impl ScrollProcessor {
         }
 
         let start = std::time::Instant::now();
-
+        let mut rng = rand::rng();
         let query_filter = random_filter(
+            &mut rng,
             &self.args.keywords,
             &self.args.float_payloads,
             &self.args.int_payloads,

--- a/src/search.rs
+++ b/src/search.rs
@@ -12,6 +12,7 @@ use qdrant_client::qdrant::{
     QueryBatchPointsBuilder, QueryPointsBuilder, ScoredPoint, SearchParamsBuilder, SparseIndices,
     VectorInput,
 };
+use rand::Rng;
 
 use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;
@@ -57,11 +58,11 @@ impl SearchProcessor {
         }
     }
 
-    fn get_sparse_queries(&self) -> Vec<(Vec<f32>, Option<SparseIndices>, Option<String>)> {
+    fn get_sparse_queries(&self, rng: &mut impl Rng) -> Vec<(Vec<f32>, Option<SparseIndices>, Option<String>)> {
         if let Some(sparsity) = self.args.sparse_vectors {
             let name = format!(
                 "{}_sparse",
-                random_vector_name(self.args.sparse_vectors_per_point)
+                random_vector_name(rng, self.args.sparse_vectors_per_point)
             );
 
             (0..self.args.search_batch_size)
@@ -81,9 +82,9 @@ impl SearchProcessor {
         }
     }
 
-    fn get_dense_queries(&self) -> Vec<(Vec<f32>, Option<SparseIndices>, Option<String>)> {
+    fn get_dense_queries(&self, rng: &mut impl Rng) -> Vec<(Vec<f32>, Option<SparseIndices>, Option<String>)> {
         let name = if self.args.vectors_per_point > 1 {
-            let name = random_vector_name(self.args.vectors_per_point);
+            let name = random_vector_name(rng, self.args.vectors_per_point);
             Some(name)
         } else {
             None
@@ -170,7 +171,7 @@ impl SearchProcessor {
         }
 
         let start = std::time::Instant::now();
-
+        let mut rng = rand::rng();
         let has_sparse = self.args.sparse_vectors.is_some();
         let has_dense = self.args.vectors_per_point > 0;
 
@@ -182,12 +183,13 @@ impl SearchProcessor {
         };
 
         let query_batch = if use_sparse {
-            self.get_sparse_queries()
+            self.get_sparse_queries(&mut rng)
         } else {
-            self.get_dense_queries()
+            self.get_dense_queries(&mut rng)
         };
 
         let query_filter = random_filter(
+            &mut rng,
             &self.args.keywords,
             &self.args.float_payloads,
             &self.args.int_payloads,

--- a/src/search.rs
+++ b/src/search.rs
@@ -68,6 +68,7 @@ impl SearchProcessor {
             (0..self.args.search_batch_size)
                 .map(|_| {
                     let sparse_vector_tuples = random_sparse_vector(
+                        rng,
                         self.args.sparse_dim.unwrap_or(self.args.dim),
                         sparsity,
                     );
@@ -93,7 +94,7 @@ impl SearchProcessor {
         (0..self.args.search_batch_size)
             .map(|_| {
                 (
-                    random_dense_vector(self.args.dim, false),
+                    random_dense_vector(rng, self.args.dim, false),
                     None,
                     name.clone(),
                 )

--- a/src/search.rs
+++ b/src/search.rs
@@ -176,7 +176,7 @@ impl SearchProcessor {
         let has_dense = self.args.vectors_per_point > 0;
 
         let use_sparse = match (has_sparse, has_dense) {
-            (true, true) => rand::random::<bool>(),
+            (true, true) => rng.random_bool(0.5),
             (true, false) => true,
             (false, true) => false,
             (false, false) => panic!("No sparse or dense vectors"),

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -158,7 +158,7 @@ impl UpsertProcessor {
             points.push(PointStruct::new(
                 point_id,
                 vectors,
-                random_payload(&self.args),
+                random_payload(&mut rng, &self.args),
             ));
         }
 
@@ -194,7 +194,7 @@ impl UpsertProcessor {
         if self.args.set_payload {
             let mut request_builder = SetPayloadPointsBuilder::new(
                 self.args.collection_name.clone(),
-                random_payload(&self.args),
+                random_payload(&mut rng, &self.args),
             )
             .points_selector(batch_ids)
             .wait(self.args.wait_on_upsert);

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -116,13 +116,13 @@ impl UpsertProcessor {
                 let vectors_map: HashMap<_, _> = (0..self.args.vectors_per_point)
                     .map(|i| {
                         let vector_name = format!("{i}");
-                        let vector = random_vector(&self.args);
+                        let vector = random_vector(&mut rng, &self.args);
                         (vector_name, vector)
                     })
                     .collect();
                 vectors_map.into()
             } else {
-                random_vector(&self.args).into()
+                random_vector(&mut rng, &self.args).into()
             };
 
             let vectors: Vectors = if let Some(sparsity) = self.args.sparse_vectors {
@@ -131,6 +131,7 @@ impl UpsertProcessor {
                 for i in 0..self.args.sparse_vectors_per_point {
                     let vector_name = format!("{i}_sparse");
                     let vector = Vector::from(random_sparse_vector(
+                        &mut rng,
                         self.args.sparse_dim.unwrap_or(self.args.dim),
                         sparsity,
                     ));


### PR DESCRIPTION
Start centralizing the creation of `rand` instances.

Motivation:
- no need to re-fetch the thread local cached `ThreadRng`
- a single entry `rand` entry point will enable us to use faster instances  
- set seed for top level `rand `