### PR TITLE
Switch to Jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1916,6 +1917,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ uuid = { version = "1.20.0", features = ["serde", "v4"] }
 env_logger = "0.11.8"
 indicatif-log-bridge = "0.2.3"
 tracing = { version = "0.1.44", features = ["log"] }
+[target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+tikv-jemallocator = { version = "0.6.1", features = [
+    "unprefixed_malloc_on_supported_platforms",
+    "background_threads",
+] }
 
 [profile.release]
 lto = "fat"

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,13 @@ mod stats;
 mod upload;
 mod upsert;
 
+#[cfg(all(
+    not(target_env = "msvc"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 async fn run_benchmark(args: Args, stopped: Arc<AtomicBool>) -> Result<()> {
     if args.search_quality && args.search_exact {
         println!("Ignoring `exact` flag because `search_quality` is also enabled!");


### PR DESCRIPTION
`bfb` allocates a lot due to the high amount of requests cloning.

Switching to Jemalloc gives a higher throughput.

TODO: provide numbers