### PR TITLE
Allow passing a bool to `--on-disk-payload`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use std::{fmt, str};
 
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use qdrant_client::qdrant;
 
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
@@ -162,7 +162,7 @@ pub struct Args {
     pub max_segment_size: Option<usize>,
 
     /// On disk payload
-    #[clap(long, default_value_t = true)]
+    #[clap(long, default_value_t = true, action = ArgAction::Set)]
     pub on_disk_payload: bool,
 
     /// On disk payload


### PR DESCRIPTION
In bb4239938abf6a8466d9165dbf105536ee38d47b the default value for `--on-disk-payload` was set to `true`. However, this flag doesn't allow passing parameters, meaning using `--on-disk-payload false` is currently not possible.
This PR allows passing a bool again without touching the default behavior.

Before:
```bash
--on-disk-payload  # No parameter allowed, providing this arg equals to `true` but it was already defaulting to `true`. 
    On disk payload

```

PR:
```bash
--on-disk-payload <ON_DISK_PAYLOAD> # We can pass `true` and `false` but still defaults to `true`.
    On disk payload [default: true] [possible values: true, false]
```


I also checked other places but this seems to be the only case.