### PR TITLE
Add --keywords-length-multiplier

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -193,6 +193,12 @@ pub struct Args {
     #[clap(long, short = 'k', value_parser = parse_number)]
     pub keywords: Vec<usize>,
 
+    /// Multiplies the length of keyword payload values by a given factor. Can be used to test larger keyword payloads.
+    ///
+    /// Note: This must be set for both, uspertions and searches (in case they're running in parallel) to prevent empty results due to different keywords being used.
+    #[clap(long, value_parser = parse_number, default_value_t = 1)]
+    pub keywords_length_multiplier: usize,
+
     /// Maximum number of keywords per point
     #[clap(long, value_parser = parse_number, default_value_t = 1)]
     pub max_keywords: usize,

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,10 +8,10 @@ use qdrant_client::qdrant::{
     Condition, Datatype, Filter, GeoPoint, GeoRadius, Range, RepeatedStrings, Vector,
 };
 use qdrant_client::{Payload, Qdrant, QdrantError};
+use rand::Rng;
 use rand::distr::Distribution;
 use rand::prelude::SliceRandom;
 use rand::seq::IndexedRandom;
-use rand::Rng;
 use serde_json::json;
 use std::time::Duration;
 use tokio::time::interval;
@@ -53,9 +53,8 @@ pub struct Timing {
 pub fn random_text(rng: &mut impl Rng, num_words: usize, vocab_size: usize) -> String {
     let zipf = rand_distr::Zipf::new(f64::from(vocab_size as u32), 1.03).unwrap();
 
-    let zipf_distributed_words: Vec<usize> = (0..num_words)
-        .map(|_| zipf.sample(rng) as usize)
-        .collect();
+    let zipf_distributed_words: Vec<usize> =
+        (0..num_words).map(|_| zipf.sample(rng) as usize).collect();
 
     let words: Vec<_> = zipf_distributed_words
         .iter()
@@ -65,12 +64,16 @@ pub fn random_text(rng: &mut impl Rng, num_words: usize, vocab_size: usize) -> S
     words.join(" ")
 }
 
-pub fn random_keyword(rng: &mut impl Rng, num_variants: usize) -> String {
+pub fn random_keyword(
+    rng: &mut impl Rng,
+    num_variants: usize,
+    keyword_len_multiplier: usize,
+) -> String {
     let variant = rng.random_range(0..num_variants);
-    format!("keyword_{variant}")
+    format!("keyword_{variant}").repeat(keyword_len_multiplier)
 }
 
-fn random_geo_point(rng: &mut impl Rng,) -> GeoPoint {
+fn random_geo_point(rng: &mut impl Rng) -> GeoPoint {
     GeoPoint {
         lat: BERLIN.lat + rng.random_range(-GEO_RADIUS_DEG..=GEO_RADIUS_DEG),
         lon: BERLIN.lon + rng.random_range(-GEO_RADIUS_DEG..=GEO_RADIUS_DEG),
@@ -95,11 +98,14 @@ pub fn random_payload(rng: &mut impl Rng, args: &Args) -> Payload {
     for (idx, variants) in args.keywords.iter().enumerate() {
         let payload_name = keyword_payload_name(idx);
         if args.max_keywords == 1 {
-            payload.insert(payload_name, random_keyword(rng, *variants));
+            payload.insert(
+                payload_name,
+                random_keyword(rng, *variants, args.keywords_length_multiplier),
+            );
         } else {
             let count = rng.random_range(1..=args.max_keywords);
             let values = (0..count)
-                .map(|_| random_keyword(rng, *variants))
+                .map(|_| random_keyword(rng, *variants, args.keywords_length_multiplier))
                 .collect::<Vec<_>>();
             payload.insert(payload_name, values);
         }
@@ -175,6 +181,7 @@ pub fn random_filter(
     geo_payloads: bool,
     bool_payloads: bool,
     text_payloads_vocab: Option<usize>,
+    keyword_len_multiplier: usize,
 ) -> Option<Filter> {
     let mut filter = Filter {
         should: vec![],
@@ -191,11 +198,15 @@ pub fn random_filter(
 
         let condition = if let Some(match_any) = match_any {
             let strings = (0..match_any)
-                .map(|_| random_keyword(rng, keyword_variants))
+                .map(|_| random_keyword(rng, keyword_variants, keyword_len_multiplier))
                 .collect();
             MatchValue::Keywords(RepeatedStrings { strings })
         } else {
-            MatchValue::Keyword(random_keyword(rng, keyword_variants))
+            MatchValue::Keyword(random_keyword(
+                rng,
+                keyword_variants,
+                keyword_len_multiplier,
+            ))
         };
 
         have_any = true;

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -70,6 +70,7 @@ impl ScrollProcessor {
                     .text_payload_vocabulary
                     .unwrap_or(DEFAULT_VOCAB_SIZE)
             }),
+            args.keywords_length_multiplier,
         );
 
         let mut request_builder = ScrollPointsBuilder::new(self.args.collection_name.clone())

--- a/src/search.rs
+++ b/src/search.rs
@@ -209,6 +209,7 @@ impl SearchProcessor {
                     .text_payload_vocabulary
                     .unwrap_or(crate::common::DEFAULT_VOCAB_SIZE)
             }),
+            self.args.keywords_length_multiplier,
         );
 
         let mut quantization_params_builder = QuantizationSearchParamsBuilder::default()


### PR DESCRIPTION
Adds a new arg to `bfb` allowing to use larger keyword payloads in benchmarks.

I did this change for some benchmarks and thought it makes sense to add it to bfb in general.
Since it was only for benchmarks, I haven't implement it for other payload types (yet).

Please let me know if you have any suggestions or don't think it should be added to bfb