### PR TITLE
Fix request building

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -142,19 +142,23 @@ impl SearchProcessor {
         let query = Query::new_nearest(vector);
 
         if let Some(prefetch_limit) = self.args.prefetch {
-            let prefetch_query = PrefetchQueryBuilder::default();
-
-            prefetch_query.query(query.clone());
-
-            let mut params = SearchParamsBuilder::default()
+            let mut prefetch_params = SearchParamsBuilder::default()
                 .quantization(QuantizationSearchParamsBuilder::default().rescore(false));
 
-            if let Some(hnsw_ef) = self.args.hnsw_ef_construct {
-                params = params.hnsw_ef(hnsw_ef as u64);
+            if let Some(hnsw_ef) = self.args.search_hnsw_ef {
+                prefetch_params = prefetch_params.hnsw_ef(hnsw_ef as u64);
             }
 
-            request_builder = request_builder.params(params);
-            request_builder = request_builder.limit(prefetch_limit as u64);
+            let prefetch = PrefetchQueryBuilder::default()
+                .query(query.clone())
+                .params(prefetch_params)
+                .limit(prefetch_limit as u64)
+                .build();
+
+            request_builder = request_builder.prefetch(vec![prefetch]);
+            request_builder = request_builder.params(search_params);
+        } else {
+            request_builder = request_builder.params(search_params);
         }
 
         request_builder = request_builder.query(query);
@@ -162,8 +166,6 @@ impl SearchProcessor {
         if let Some(read_consistency) = self.args.read_consistency {
             request_builder = request_builder.read_consistency(read_consistency);
         }
-
-        request_builder = request_builder.params(search_params);
 
         request_builder
     }
@@ -226,7 +228,7 @@ impl SearchProcessor {
             .quantization(quantization_params_builder)
             .indexed_only(self.args.indexed_only.unwrap_or_default());
 
-        if let Some(hnsw_ef) = self.args.hnsw_ef_construct {
+        if let Some(hnsw_ef) = self.args.search_hnsw_ef {
             search_params = search_params.hnsw_ef(hnsw_ef as u64);
         }
 


### PR DESCRIPTION
Fix several issues in the request building:  

1. Prefetch builder result discarded - `PrefetchQueryBuilder.query()` returns a new builder, but the result was thrown away. Now the builder is properly chained: `.query().params().limit().build()`.
  3. Built prefetch never attached - The built `PrefetchQuery` is now added to the request via `.prefetch(vec![prefetch])`.
  4. Wrong arg for `hnsw_ef` - Both occurrences of `self.args.hnsw_ef_construct` in the search path were changed to `self.args.search_hnsw_ef` (the parameter meant for search, not index construction).
  5. `search_params` overwriting prefetch params - The prefetch branch now sets its own params on the prefetch query, and `search_params` is applied to the top-level request in both branches without conflict.

Also improving the Rust client to avoid this issue completely in the future https://github.com/qdrant/rust-client/pull/276
