### PR TITLE
fix: fetch http(s) `type: file` vector sources, reject other schemes

### DIFF
--- a/examples/upload-config.yaml
+++ b/examples/upload-config.yaml
@@ -35,7 +35,9 @@ collection:
     - name: text-emb
       size: 384
       source: random
-      # Load real vectors from an .fbin file instead:
+      # Load real vectors from an .fbin file instead. `path` may be a local path
+      # or an http(s):// URL, which is downloaded once and cached under
+      # $BFB_DATASETS_DIR (default ./datasets).
       # source:
       #   type: file
       #   path: /data/text-emb.fbin

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -73,13 +73,7 @@ impl UploadConfig {
                 bail!("duplicate vector name {n:?}");
             }
             match &v.source {
-                VectorSource::File { path, .. }
-                    if !path.starts_with("s3://")
-                        && !path.starts_with("http")
-                        && !Path::new(path).exists() =>
-                {
-                    bail!("vector source file not found: {path}");
-                }
+                VectorSource::File { path, .. } => validate_file_source_path(path)?,
                 VectorSource::Dataset { dataset } => dataset.validate_inline()?,
                 _ => {}
             }
@@ -178,6 +172,26 @@ impl UploadConfig {
 
         Ok(())
     }
+}
+
+/// Validate a `source: {type: file}` path. `http(s)://` URLs are fetched and
+/// cached on first use; local paths must already exist. Other URL schemes are
+/// rejected up front rather than failing when the file is opened.
+pub(crate) fn validate_file_source_path(path: &str) -> Result<()> {
+    if crate::dataset::is_remote_url(path) {
+        return Ok(());
+    }
+    if let Some((scheme, _)) = path.split_once("://") {
+        bail!(
+            "vector source path uses unsupported scheme {scheme:?}: {path}\n\
+             `type: file` accepts a local path or an http(s):// URL. \
+             For data hosted on S3, use its https:// URL, or a `type: dataset` source."
+        );
+    }
+    if !Path::new(path).exists() {
+        bail!("vector source file not found: {path}");
+    }
+    Ok(())
 }
 
 // --------------------------- serde helpers -------------------------------
@@ -468,6 +482,50 @@ collection:
       bogus: 1
 "#;
         assert!(serde_yaml::from_str::<UploadConfig>(yaml).is_err());
+    }
+
+    fn config_with_vector_path(path: &str) -> UploadConfig {
+        let yaml = format!(
+            r#"
+collection:
+  vectors:
+    - size: 128
+      source:
+        type: file
+        path: {path}
+"#
+        );
+        serde_yaml::from_str(&yaml).unwrap()
+    }
+
+    #[test]
+    fn accepts_http_vector_source_path() {
+        // Remote URLs are fetched lazily, so validation must not stat them.
+        config_with_vector_path("https://example.com/vectors.fbin")
+            .validate()
+            .unwrap();
+        config_with_vector_path("http://example.com/vectors.fbin")
+            .validate()
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_s3_vector_source_path() {
+        let err = config_with_vector_path("s3://bucket/vectors.fbin")
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unsupported scheme"), "{err}");
+        assert!(err.contains("s3"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_local_vector_source_path() {
+        let err = config_with_vector_path("/nonexistent/vectors.fbin")
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not found"), "{err}");
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -78,7 +78,7 @@ collection:
       source: random             # default=random
       # source:
       #   type: file             # enum           [random | file | dataset]
-      #   path: ./vectors.fbin   # string         required for file (local path, http(s)://, or s3://)
+      #   path: ./vectors.fbin   # string         required for file (local path or http(s):// URL, cached on download)
       #   strategy: random-sample # enum          default=random-sample  [random-sample | from-start]
       # source:
       #   type: dataset          # inline dataset definition (vector-db-benchmark format)
@@ -212,7 +212,7 @@ mod tests {
                     // File source so `path`/`strategy` are exercised too;
                     // a remote path keeps `validate()` from checking existence.
                     source: VectorSource::File {
-                        path: "s3://bucket/vectors.fbin".to_string(),
+                        path: "https://example.com/vectors.fbin".to_string(),
                         strategy: FileStrategy::RandomSample,
                     },
                 }],

--- a/src/config/search.rs
+++ b/src/config/search.rs
@@ -4,14 +4,12 @@
 //! to query, optional payload filters). The *how* of searching (number of
 //! queries, batch size, threads, parallelism, uri, …) stays on the CLI.
 
-use std::path::Path;
-
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
     DatatypeKind, PayloadSource, PayloadType, SparseKind, SparseSource, VectorSource,
-    default_collection_name, string_or_struct,
+    default_collection_name, string_or_struct, validate_file_source_path,
 };
 
 /// Top-level document: `{ collection: { name }, requests: [ … ] }`.
@@ -101,13 +99,8 @@ impl SearchRequestConfig {
         match self {
             SearchRequestConfig::Dense { size, source, .. } => {
                 match source {
-                    VectorSource::File { path, .. }
-                        if !path.starts_with("s3://")
-                            && !path.starts_with("http")
-                            && !Path::new(path).exists() =>
-                    {
-                        bail!("requests[{index}]: vector source file not found: {path}");
-                    }
+                    VectorSource::File { path, .. } => validate_file_source_path(path)
+                        .with_context(|| format!("requests[{index}]"))?,
                     // A dataset query source supplies its own query vectors, so
                     // `size` is not required to match anything here.
                     VectorSource::Dataset { dataset } => dataset.validate_inline()?,
@@ -249,6 +242,38 @@ requests:
 "#;
         let cfg: SearchConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(cfg.validate().is_err());
+    }
+
+    fn search_config_with_vector_path(path: &str) -> SearchConfig {
+        let yaml = format!(
+            r#"
+collection:
+  name: bench
+requests:
+  - kind: dense
+    size: 128
+    source:
+      type: file
+      path: {path}
+"#
+        );
+        serde_yaml::from_str(&yaml).unwrap()
+    }
+
+    #[test]
+    fn accepts_http_query_vector_path() {
+        search_config_with_vector_path("https://example.com/queries.fbin")
+            .validate()
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_s3_query_vector_path() {
+        let err = search_config_with_vector_path("s3://bucket/queries.fbin")
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("requests[0]"), "{err}");
     }
 
     #[test]

--- a/src/dataset/download.rs
+++ b/src/dataset/download.rs
@@ -186,8 +186,7 @@ mod tests {
     #[test]
     fn downloads_remote_file_once_and_caches_it() {
         let body = b"fbin-payload".to_vec();
-        // Only one request is ever served: a second download attempt would hang
-        // the accept loop rather than succeed, proving the cache is used.
+        // Only one request is served; if the cache is not used, the second call will fail.
         let (url, server) = crate::dataset::test_http::serve_once(body.clone(), 1);
 
         let dir = tempfile::tempdir().unwrap();

--- a/src/dataset/download.rs
+++ b/src/dataset/download.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use flate2::read::GzDecoder;
 use tar::Archive;
+use tempfile::NamedTempFile;
 
 use super::config::{DatasetKind, ResolvedDatasetConfig};
 
@@ -25,22 +26,22 @@ pub fn ensure_local_file(datasets_dir: &Path, path: &str) -> Result<PathBuf> {
         return Ok(PathBuf::from(path));
     }
 
-    let target = datasets_dir.join("files").join(cache_key(path));
+    let cache_dir = datasets_dir.join("files");
+    let target = cache_dir.join(cache_key(path));
     if target.exists() {
         return Ok(target);
     }
 
+    fs::create_dir_all(&cache_dir)
+        .with_context(|| format!("failed to create {}", cache_dir.display()))?;
+
     println!("Downloading {path}...");
-    let tmp = download_to_temp(path)?;
-    let parent = target
-        .parent()
-        .expect("cache path always has a `files` parent");
-    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
-    // Copy rather than rename: the temp file lives on the system temp mount,
-    // which is often a different filesystem than the datasets dir.
-    fs::copy(&tmp, &target)
-        .with_context(|| format!("failed to copy download to {}", target.display()))?;
-    let _ = fs::remove_file(&tmp);
+    // Download into the cache dir, then rename into place. The rename is atomic (same
+    // filesystem), so an interrupted or failed download never leaves a truncated file
+    // at `target` that later runs would happily reuse.
+    let tmp = download_to_temp(path, &cache_dir)?;
+    tmp.persist(&target)
+        .with_context(|| format!("failed to install download at {}", target.display()))?;
     Ok(target)
 }
 
@@ -78,14 +79,20 @@ pub fn ensure_downloaded(datasets_dir: &Path, config: &ResolvedDatasetConfig) ->
         )
     })?;
 
+    let staging_dir = target.parent().unwrap_or(datasets_dir);
+    fs::create_dir_all(staging_dir)
+        .with_context(|| format!("failed to create {}", staging_dir.display()))?;
+
     println!("Downloading dataset {:?} from {link}...", config.name);
-    let tmp = download_to_temp(link)?;
-    install_download(&tmp, &target, link, config.kind)?;
-    let _ = fs::remove_file(&tmp);
+    // Stage next to the target so installing it is a same-filesystem rename.
+    let tmp = download_to_temp(link, staging_dir)?;
+    install_download(tmp, &target, link, config.kind)?;
     Ok(target)
 }
 
-fn download_to_temp(url: &str) -> Result<PathBuf> {
+/// Download `url` into a temporary file inside `dir`. The file is deleted when the
+/// returned handle is dropped, so an aborted download leaves nothing behind.
+fn download_to_temp(url: &str, dir: &Path) -> Result<NamedTempFile> {
     let agent = ureq::Agent::new_with_config(
         ureq::config::Config::builder()
             .user_agent("Mozilla/5.0")
@@ -97,36 +104,46 @@ fn download_to_temp(url: &str) -> Result<PathBuf> {
         .with_context(|| format!("failed to download {url}"))?;
 
     let mut reader = response.into_body().into_reader();
-    let mut tmp = tempfile::NamedTempFile::new().context("failed to create temp file")?;
+    let mut tmp = NamedTempFile::new_in(dir)
+        .with_context(|| format!("failed to create temp file in {}", dir.display()))?;
     io::copy(&mut reader, tmp.as_file_mut()).context("failed to write download")?;
-    // `keep()` disables auto-deletion so the file survives until `ensure_downloaded`
-    // installs it and removes it explicitly; otherwise the `TempPath` would drop and
-    // unlink the file the moment this function returns.
-    let (_, path) = tmp.keep().context("failed to persist temp download")?;
-    Ok(path)
+    Ok(tmp)
 }
 
-fn install_download(tmp: &Path, target: &Path, link: &str, kind: DatasetKind) -> Result<()> {
+fn install_download(
+    tmp: NamedTempFile,
+    target: &Path,
+    link: &str,
+    kind: DatasetKind,
+) -> Result<()> {
     if link.ends_with(".tgz") || link.ends_with(".tar.gz") {
-        fs::create_dir_all(target)
-            .with_context(|| format!("failed to create {}", target.display()))?;
-        let file = File::open(tmp).with_context(|| format!("failed to open {}", tmp.display()))?;
+        // Extract into a staging dir and rename it into place, so a failed extraction
+        // does not leave a half-populated dataset dir that later runs treat as complete.
+        let parent = target.parent().unwrap_or(Path::new("."));
+        let staging = tempfile::TempDir::new_in(parent)
+            .with_context(|| format!("failed to create staging dir in {}", parent.display()))?;
+        let file = File::open(tmp.path())
+            .with_context(|| format!("failed to open {}", tmp.path().display()))?;
         let decoder = GzDecoder::new(file);
         let mut archive = Archive::new(decoder);
         archive
-            .unpack(target)
+            .unpack(staging.path())
             .with_context(|| format!("failed to extract archive into {}", target.display()))?;
+        let staged = staging.keep();
+        fs::rename(&staged, target).with_context(|| {
+            format!(
+                "failed to move extracted archive from {} to {}",
+                staged.display(),
+                target.display()
+            )
+        })?;
         return Ok(());
     }
 
     match kind {
         DatasetKind::H5 => {
-            if let Some(parent) = target.parent() {
-                fs::create_dir_all(parent)
-                    .with_context(|| format!("failed to create {}", parent.display()))?;
-            }
-            fs::copy(tmp, target)
-                .with_context(|| format!("failed to copy download to {}", target.display()))?;
+            tmp.persist(target)
+                .with_context(|| format!("failed to install download at {}", target.display()))?;
         }
         DatasetKind::Tar | DatasetKind::Sparse => {
             bail!(
@@ -207,5 +224,19 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let err = ensure_local_file(dir.path(), "http://127.0.0.1:1/vectors.fbin").unwrap_err();
         assert!(err.to_string().contains("failed to download"), "{err}");
+    }
+
+    #[test]
+    fn failed_download_leaves_no_cache_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = "http://127.0.0.1:1/vectors.fbin";
+        assert!(ensure_local_file(dir.path(), url).is_err());
+
+        // A partial download must not be persisted under its cache key, otherwise every
+        // later run would short-circuit on the truncated file.
+        let cached: Vec<_> = fs::read_dir(dir.path().join("files"))
+            .map(|entries| entries.map(|e| e.unwrap().path()).collect())
+            .unwrap_or_default();
+        assert!(cached.is_empty(), "cache dir must be empty, got {cached:?}");
     }
 }

--- a/src/dataset/download.rs
+++ b/src/dataset/download.rs
@@ -1,4 +1,6 @@
+use std::collections::hash_map::DefaultHasher;
 use std::fs::{self, File};
+use std::hash::{Hash, Hasher};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -7,6 +9,59 @@ use flate2::read::GzDecoder;
 use tar::Archive;
 
 use super::config::{DatasetKind, ResolvedDatasetConfig};
+
+/// Is `path` an `http(s)://` URL rather than a local filesystem path?
+pub fn is_remote_url(path: &str) -> bool {
+    path.starts_with("http://") || path.starts_with("https://")
+}
+
+/// Resolve a vector-source path to a local file, downloading it first if it is
+/// an `http(s)://` URL. Remote files are cached under `datasets_dir/files/` and
+/// keyed by URL, so repeated runs download once.
+///
+/// Local paths are returned unchanged.
+pub fn ensure_local_file(datasets_dir: &Path, path: &str) -> Result<PathBuf> {
+    if !is_remote_url(path) {
+        return Ok(PathBuf::from(path));
+    }
+
+    let target = datasets_dir.join("files").join(cache_key(path));
+    if target.exists() {
+        return Ok(target);
+    }
+
+    println!("Downloading {path}...");
+    let tmp = download_to_temp(path)?;
+    let parent = target
+        .parent()
+        .expect("cache path always has a `files` parent");
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    // Copy rather than rename: the temp file lives on the system temp mount,
+    // which is often a different filesystem than the datasets dir.
+    fs::copy(&tmp, &target)
+        .with_context(|| format!("failed to copy download to {}", target.display()))?;
+    let _ = fs::remove_file(&tmp);
+    Ok(target)
+}
+
+/// A filesystem-safe cache name for `url`: its basename prefixed with a hash of
+/// the full URL, so two hosts serving `vectors.fbin` don't collide.
+fn cache_key(url: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    url.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    let basename = url
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or("download")
+        .split(['?', '#'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or("download");
+
+    format!("{hash:016x}-{basename}")
+}
 
 /// Ensure the dataset files exist locally, downloading and extracting if needed.
 pub fn ensure_downloaded(datasets_dir: &Path, config: &ResolvedDatasetConfig) -> Result<PathBuf> {
@@ -81,4 +136,77 @@ fn install_download(tmp: &Path, target: &Path, link: &str, kind: DatasetKind) ->
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_remote_urls() {
+        assert!(is_remote_url("https://example.com/v.fbin"));
+        assert!(is_remote_url("http://example.com/v.fbin"));
+        assert!(!is_remote_url("s3://bucket/v.fbin"));
+        assert!(!is_remote_url("./v.fbin"));
+        assert!(!is_remote_url("/abs/v.fbin"));
+    }
+
+    #[test]
+    fn local_paths_pass_through_unchanged() {
+        let dir = Path::new("/tmp/datasets");
+        assert_eq!(
+            ensure_local_file(dir, "./vectors.fbin").unwrap(),
+            PathBuf::from("./vectors.fbin")
+        );
+    }
+
+    #[test]
+    fn cache_key_keeps_basename_and_disambiguates_hosts() {
+        let a = cache_key("https://a.example.com/vectors.fbin");
+        let b = cache_key("https://b.example.com/vectors.fbin");
+        assert!(a.ends_with("-vectors.fbin"), "{a}");
+        assert!(b.ends_with("-vectors.fbin"), "{b}");
+        assert_ne!(a, b, "same basename on different hosts must not collide");
+        assert_eq!(a, cache_key("https://a.example.com/vectors.fbin"));
+    }
+
+    #[test]
+    fn cache_key_strips_query_and_fragment() {
+        assert!(
+            cache_key("https://x.com/vectors.fbin?token=abc").ends_with("-vectors.fbin"),
+            "query string must not leak into the cache filename"
+        );
+    }
+
+    #[test]
+    fn cache_key_tolerates_trailing_slash() {
+        assert!(cache_key("https://example.com/data/").ends_with("-data"));
+    }
+
+    #[test]
+    fn downloads_remote_file_once_and_caches_it() {
+        let body = b"fbin-payload".to_vec();
+        // Only one request is ever served: a second download attempt would hang
+        // the accept loop rather than succeed, proving the cache is used.
+        let (url, server) = crate::dataset::test_http::serve_once(body.clone(), 1);
+
+        let dir = tempfile::tempdir().unwrap();
+        let first = ensure_local_file(dir.path(), &url).unwrap();
+        assert!(first.starts_with(dir.path().join("files")));
+        assert_eq!(std::fs::read(&first).unwrap(), body);
+
+        // Second call must hit the cache and return the same path.
+        let second = ensure_local_file(dir.path(), &url).unwrap();
+        assert_eq!(first, second);
+
+        assert_eq!(server.join().unwrap(), 1, "file should be downloaded once");
+    }
+
+    #[test]
+    fn reports_download_failure_instead_of_panicking() {
+        // Nothing is listening on this port.
+        let dir = tempfile::tempdir().unwrap();
+        let err = ensure_local_file(dir.path(), "http://127.0.0.1:1/vectors.fbin").unwrap_err();
+        assert!(err.to_string().contains("failed to download"), "{err}");
+    }
 }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -8,6 +8,7 @@ mod sources;
 mod upload;
 
 pub use config::DatasetConfig;
+pub use download::{ensure_local_file, is_remote_url};
 pub use reader::DatasetReader;
 pub use sources::UploadDatasetSources;
 pub use upload::resolve_num_vectors;
@@ -17,4 +18,42 @@ pub fn default_datasets_dir() -> std::path::PathBuf {
     std::env::var_os("BFB_DATASETS_DIR")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|| std::path::PathBuf::from("datasets"))
+}
+
+/// A throwaway HTTP server for exercising the download path in tests.
+#[cfg(test)]
+pub(crate) mod test_http {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread::JoinHandle;
+
+    /// Serve `body` over HTTP to exactly `hits` clients, then stop. Returns the
+    /// URL and a handle yielding how many requests were actually served, so a
+    /// caller can assert that a cached file was not re-fetched.
+    pub(crate) fn serve_once(body: Vec<u8>, hits: usize) -> (String, JoinHandle<usize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/vectors.fbin", listener.local_addr().unwrap());
+
+        let handle = std::thread::spawn(move || {
+            let mut served = 0;
+            for _ in 0..hits {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    break;
+                };
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(header.as_bytes());
+                let _ = stream.write_all(&body);
+                let _ = stream.flush();
+                served += 1;
+            }
+            served
+        });
+
+        (url, handle)
+    }
 }

--- a/src/fbin_reader.rs
+++ b/src/fbin_reader.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Result, bail};
 use memmap2::{Mmap, MmapOptions};
 use std::fs::OpenOptions;
-use std::mem::transmute;
 use std::path::Path;
 
+#[derive(Debug)]
 pub struct FBinReader {
     pub num_vectors: i32,
     pub dim: i32,
@@ -40,6 +40,34 @@ impl FBinReader {
         let num_vectors = i32::from_le_bytes(num_vectors_raw.try_into().unwrap());
         let dim = i32::from_le_bytes(num_dim_raw.try_into().unwrap());
 
+        if num_vectors <= 0 || dim <= 0 {
+            bail!(
+                "vector file {} has an invalid fbin header: num_vectors={num_vectors}, dim={dim}",
+                path.display()
+            );
+        }
+
+        // The declared payload must fit in the file, otherwise `read_vector` would read
+        // past the end of the mapping on a truncated or malformed file.
+        let expected_size = (num_vectors as usize)
+            .checked_mul(dim as usize)
+            .and_then(|values| values.checked_mul(size_of::<f32>()))
+            .and_then(|payload| payload.checked_add(header_size))
+            .with_context(|| {
+                format!(
+                    "vector file {} declares an unrepresentable size: {num_vectors} x {dim}",
+                    path.display()
+                )
+            })?;
+        if mmap.len() < expected_size {
+            bail!(
+                "vector file {} is truncated: header declares {num_vectors} vectors of {dim} \
+                 dimensions ({expected_size} bytes), but the file is {} bytes",
+                path.display(),
+                mmap.len(),
+            );
+        }
+
         Ok(FBinReader {
             num_vectors,
             dim,
@@ -49,12 +77,16 @@ impl FBinReader {
         })
     }
 
+    /// Vector at `idx`. Panics if `idx >= num_vectors`.
     pub fn read_vector(&self, idx: usize) -> &[f32] {
-        let vector_size = self.dim as usize * size_of::<f32>();
+        let dim = self.dim as usize;
+        let vector_size = dim * size_of::<f32>();
         let vector_offset = self.header_size + idx * vector_size;
         let vector_raw = &self.mmap[vector_offset..vector_offset + vector_size];
-        let arr: &[f32] = unsafe { transmute(vector_raw) };
-        &arr[..self.dim as usize]
+        // SAFETY: the slice above is bounds-checked and holds exactly `dim` f32 values.
+        // It is 4-byte aligned because the mmap base is page aligned, the header is 8
+        // bytes and every vector is a multiple of 4 bytes.
+        unsafe { std::slice::from_raw_parts(vector_raw.as_ptr().cast::<f32>(), dim) }
     }
 }
 
@@ -69,5 +101,70 @@ impl Iterator for FBinReader {
         let vector = self.read_vector(self.iter_offset).to_vec();
         self.iter_offset += 1;
         Some(vector)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Write an fbin file with the given header, followed by `payload` vector values.
+    fn write_fbin(num_vectors: i32, dim: i32, payload: &[f32]) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&num_vectors.to_le_bytes()).unwrap();
+        file.write_all(&dim.to_le_bytes()).unwrap();
+        for value in payload {
+            file.write_all(&value.to_le_bytes()).unwrap();
+        }
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn reads_vectors_of_a_valid_file() {
+        let file = write_fbin(2, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let reader = FBinReader::new(file.path()).unwrap();
+        assert_eq!(reader.num_vectors, 2);
+        assert_eq!(reader.dim, 3);
+        assert_eq!(reader.read_vector(0), [1.0, 2.0, 3.0]);
+        assert_eq!(reader.read_vector(1), [4.0, 5.0, 6.0]);
+        assert_eq!(reader.count(), 2);
+    }
+
+    #[test]
+    fn rejects_truncated_payload() {
+        // Header promises 4 vectors, only 1 is present.
+        let file = write_fbin(4, 3, &[1.0, 2.0, 3.0]);
+        let err = FBinReader::new(file.path()).unwrap_err();
+        assert!(err.to_string().contains("truncated"), "{err}");
+    }
+
+    #[test]
+    fn rejects_negative_header_values() {
+        let file = write_fbin(-1, 3, &[]);
+        let err = FBinReader::new(file.path()).unwrap_err();
+        assert!(err.to_string().contains("invalid fbin header"), "{err}");
+
+        let file = write_fbin(1, -3, &[]);
+        let err = FBinReader::new(file.path()).unwrap_err();
+        assert!(err.to_string().contains("invalid fbin header"), "{err}");
+    }
+
+    #[test]
+    fn rejects_header_that_overflows_the_file_size() {
+        // 2^31-1 vectors of 2^31-1 dimensions cannot fit in any file.
+        let file = write_fbin(i32::MAX, i32::MAX, &[]);
+        let err = FBinReader::new(file.path()).unwrap_err();
+        assert!(err.to_string().contains("truncated"), "{err}");
+    }
+
+    #[test]
+    fn rejects_file_shorter_than_the_header() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&[0u8; 4]).unwrap();
+        file.flush().unwrap();
+        let err = FBinReader::new(file.path()).unwrap_err();
+        assert!(err.to_string().contains("too short"), "{err}");
     }
 }

--- a/src/fbin_reader.rs
+++ b/src/fbin_reader.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result, bail};
 use memmap2::{Mmap, MmapOptions};
 use std::fs::OpenOptions;
 use std::mem::transmute;
@@ -12,32 +13,40 @@ pub struct FBinReader {
 }
 
 impl FBinReader {
-    pub fn new(path: &Path) -> Self {
+    pub fn new(path: &Path) -> Result<Self> {
         let file = OpenOptions::new()
             .read(true)
             .write(false)
             .append(false)
             .create(false)
             .open(path)
-            .unwrap();
+            .with_context(|| format!("failed to open vector file {}", path.display()))?;
 
-        let mmap = unsafe { MmapOptions::new().map(&file).unwrap() };
+        let mmap = unsafe { MmapOptions::new().map(&file) }
+            .with_context(|| format!("failed to mmap vector file {}", path.display()))?;
+
         let int_size = size_of::<i32>();
         let dim_offset = int_size;
         let header_size = dim_offset + int_size;
+        if mmap.len() < header_size {
+            bail!(
+                "vector file {} is too short to hold an fbin header",
+                path.display()
+            );
+        }
         let num_vectors_raw = &mmap[0..dim_offset];
         let num_dim_raw = &mmap[dim_offset..header_size];
 
         let num_vectors = i32::from_le_bytes(num_vectors_raw.try_into().unwrap());
         let dim = i32::from_le_bytes(num_dim_raw.try_into().unwrap());
 
-        FBinReader {
+        Ok(FBinReader {
             num_vectors,
             dim,
             iter_offset: 0,
             header_size,
             mmap,
-        }
+        })
     }
 
     pub fn read_vector(&self, idx: usize) -> &[f32] {

--- a/src/generators/config.rs
+++ b/src/generators/config.rs
@@ -1,7 +1,6 @@
 //! YAML-config-driven point generation ([`ConfigGenerator`]).
 
 use std::collections::HashMap;
-use std::path::Path;
 
 use qdrant_client::Payload;
 use qdrant_client::qdrant::point_id::PointIdOptions;
@@ -22,7 +21,7 @@ use crate::config::{
     DatatypeKind, DistributionKind, FileStrategy, IdType, PayloadSource, PayloadSourceKind,
     PayloadType, UploadConfig, VectorConfig, VectorSource,
 };
-use crate::dataset::{UploadDatasetSources, default_datasets_dir};
+use crate::dataset::{UploadDatasetSources, default_datasets_dir, ensure_local_file};
 use crate::fbin_reader::FBinReader;
 
 /// Generates points from a parsed YAML [`UploadConfig`].
@@ -71,10 +70,13 @@ impl ConfigGenerator {
             .vectors
             .iter()
             .map(|v| match &v.source {
-                VectorSource::File { path, .. } => Some(FBinReader::new(Path::new(path))),
-                _ => None,
+                VectorSource::File { path, .. } => {
+                    let local = ensure_local_file(datasets_dir, path)?;
+                    FBinReader::new(&local).map(Some)
+                }
+                _ => Ok(None),
             })
-            .collect();
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
         let datasets = UploadDatasetSources::open(config, datasets_dir)?;
 
@@ -384,6 +386,56 @@ mod tests {
         let config: UploadConfig = serde_yaml::from_str(yaml).unwrap();
         config.validate().unwrap();
         ConfigGenerator::new(&config).unwrap()
+    }
+
+    /// Serialize `vectors` in fbin layout: `[i32 count][i32 dim][f32 data…]`.
+    fn fbin_bytes(vectors: &[Vec<f32>]) -> Vec<u8> {
+        let dim = vectors[0].len();
+        let mut bytes = (vectors.len() as i32).to_le_bytes().to_vec();
+        bytes.extend((dim as i32).to_le_bytes());
+        for v in vectors {
+            for f in v {
+                bytes.extend(f.to_le_bytes());
+            }
+        }
+        bytes
+    }
+
+    /// A `source: {type: file}` pointing at an http(s) URL must download the
+    /// file and generate points from it, not panic opening a path named "http:".
+    #[test]
+    fn generates_vectors_from_a_remote_fbin_file() {
+        let vectors = vec![vec![1.0, 2.0, 3.0, 4.0], vec![5.0, 6.0, 7.0, 8.0]];
+        let (url, server) = crate::dataset::test_http::serve_once(fbin_bytes(&vectors), 1);
+        let dir = tempfile::tempdir().unwrap();
+
+        let yaml = format!(
+            r#"
+collection:
+  name: t
+  vectors:
+    - size: 4
+      source:
+        type: file
+        path: {url}
+        strategy: from-start
+"#
+        );
+        let config: UploadConfig = serde_yaml::from_str(&yaml).unwrap();
+        config.validate().unwrap();
+
+        let generator = ConfigGenerator::new_with_datasets_dir(&config, dir.path()).unwrap();
+        let point = generator.make_point(0);
+
+        let data = match point.vectors.unwrap().vectors_options.unwrap() {
+            VectorsOptions::Vector(v) => match v.vector.unwrap() {
+                qdrant_client::qdrant::vector::Vector::Dense(d) => d.data,
+                _ => panic!("expected a dense vector"),
+            },
+            _ => panic!("expected the unnamed default vector"),
+        };
+        assert_eq!(data, vectors[0], "point 0 must come from the remote file");
+        assert_eq!(server.join().unwrap(), 1);
     }
 
     fn named(point: &PointStruct) -> HashMap<String, Vector> {

--- a/src/generators/queries.rs
+++ b/src/generators/queries.rs
@@ -23,7 +23,7 @@ use crate::config::{
     DatatypeKind, DistributionKind, FileStrategy, PayloadSourceKind, PayloadType, SparseKind,
     VectorSource,
 };
-use crate::dataset::{DatasetReader, default_datasets_dir};
+use crate::dataset::{DatasetReader, default_datasets_dir, ensure_local_file};
 use crate::fbin_reader::FBinReader;
 
 const GEO_CENTER_LAT: f64 = 52.52437;
@@ -93,7 +93,8 @@ impl ConfigSearchGenerator {
                 } => {
                     let (dense_reader, query_dataset) = match source {
                         VectorSource::File { path, .. } => {
-                            (Some(FBinReader::new(Path::new(path))), None)
+                            let local = ensure_local_file(datasets_dir, path)?;
+                            (Some(FBinReader::new(&local)?), None)
                         }
                         VectorSource::Dataset { dataset } => {
                             (None, Some(Self::open_query_dataset(dataset, datasets_dir)?))

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -21,7 +21,8 @@ pub async fn upload_data(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
     let reader = args
         .fbin
         .as_ref()
-        .map(|path| FBinReader::new(Path::new(path)));
+        .map(|path| FBinReader::new(Path::new(path)))
+        .transpose()?;
     let generator = Arc::new(LegacyGenerator::new(args.clone(), reader));
     run_upload(args, stopped, generator).await
 }


### PR DESCRIPTION
Allow https:// url only, reject s3://.

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

