### PR TITLE
feat: Unified --json results document

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,6 +14,7 @@ src/
 ├── scroll.rs        # scroll benchmarking processor
 ├── query.rs         # search/scroll entry points
 ├── processor.rs     # Processor trait + Timing measurement type
+├── results.rs       # unified `{config, results}` document written by --json
 ├── stats.rs         # benchmark run loops (parallel/RPS), stats output, throttling
 ├── save_jsonl.rs    # timing series export
 ├── fbin_reader.rs   # raw .fbin vector file reader

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ Phases that did not run are omitted: `bfb search --file …` yields only
 (`--search-quality`, or a dataset query source with ground truth). Timings are
 in seconds. The per-request `--jsonl-*` time series are unchanged.
 
+**Backward compatibility.** The three arrays `--json` used to emit at the top
+level — `server_timings`, `rps`, `full_timings` — are still written there, so
+existing `jq '.rps'` consumers keep working. As before, they mirror the last
+query phase that ran (scroll takes precedence over search), and they are absent
+when no query phase ran. They are **deprecated**: prefer `results.search` /
+`results.scroll`, which also expose `qps`, per-phase `duration_secs`, and the
+precomputed `server_time` / `request_time` summaries.
+
 ### Legacy flag-driven mode
 
 The main command runs without any subcommands, just options:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,48 @@ bfb search --file search-config.yaml -n 50k -p 8 --uri http://localhost:6334
 The legacy flag-driven search path (`bfb --skip-create --skip-upload --search …`)
 is still available when you prefer flat CLI flags over a YAML file.
 
+### Results document (`--json`)
+
+`--json <path>` writes one document describing the whole run — the parameters it
+ran with, plus a section per phase that actually executed. It works on every
+mode (`bfb upload`, `bfb search`, and legacy flag-driven runs), so phase timings
+no longer have to be scraped from stdout or timed by the calling shell.
+
+```bash
+bfb -n 1M --search --json results.json
+```
+
+```json
+{
+  "config": {
+    "bfb_version": "0.1.1",
+    "collection_name": "benchmark",
+    "num_vectors": 1000000,
+    "batch_size": 100,
+    "parallel": 2,
+    "threads": 2
+  },
+  "results": {
+    "upload": { "duration_secs": 57.8, "num_points": 1000000, "points_per_sec": 17301.0 },
+    "index":  { "wait_secs": 12.4 },
+    "search": {
+      "duration_secs": 30.1,
+      "server_timings": [0.000095, 0.000103],
+      "full_timings":   [0.001019, 0.001185],
+      "rps": [989.1], "qps": [989.1],
+      "server_time":  { "min": 0.000095, "avg": 0.000196, "p50": 0.00017, "p95": 0.00023, "max": 0.0124 },
+      "request_time": { "min": 0.001019, "avg": 0.001885, "p50": 0.00118, "p95": 0.00137, "max": 0.0379 },
+      "precision": { "avg": 0.98, "p50": 1.0 }
+    }
+  }
+}
+```
+
+Phases that did not run are omitted: `bfb search --file …` yields only
+`results.search`, and `precision` appears only when accuracy was measured
+(`--search-quality`, or a dataset query source with ground truth). Timings are
+in seconds. The per-request `--jsonl-*` time series are unchanged.
+
 ### Legacy flag-driven mode
 
 The main command runs without any subcommands, just options:
@@ -190,7 +232,7 @@ Options:
       --search-limit <SEARCH_LIMIT>
           Search limit [default: 10]
       --json <JSON>
-          Store results to csv
+          Write the benchmark results document (config + every phase) to this path
       --p9 <P9>
           Number of 9 digits to show in p99* results [default: 2]
       --collection-name <COLLECTION_NAME>

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -138,7 +138,7 @@ pub struct Args {
     #[clap(long, default_value_t = 10, value_parser = parse_number, global = true)]
     pub search_limit: usize,
 
-    /// Store results to csv
+    /// Write the benchmark results document (config + every phase) to this path
     #[clap(long, global = true)]
     pub json: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::{CommandFactory, FromArgMatches};
 use tokio::runtime;
 
 use args::{Args, Command};
+use results::{BenchmarkResults, IndexPhase};
 
 mod args;
 mod client;
@@ -16,12 +17,21 @@ mod fbin_reader;
 mod generators;
 mod processor;
 mod query;
+mod results;
 mod save_jsonl;
 mod scroll;
 mod search;
 mod stats;
 mod upload;
 mod upsert;
+
+/// Wait for the index and record how long it took.
+async fn run_wait_index(args: &Args, stopped: Arc<AtomicBool>) -> Result<IndexPhase> {
+    println!("Waiting for index to be ready...");
+    let wait_secs = collection::wait_index(args, stopped).await?;
+    println!("Index ready in {wait_secs} seconds");
+    Ok(IndexPhase { wait_secs })
+}
 
 /// `bfb search --file config.yaml`: YAML-config-driven search.
 async fn run_search(
@@ -38,7 +48,9 @@ async fn run_search(
         println!("Ignoring `exact` flag because `search_quality` is also enabled!");
     }
 
-    query::search_with_config(&args, &config, stopped).await
+    let mut results = BenchmarkResults::new(&args, Some(search_args.file.clone()));
+    results.results.search = Some(query::search_with_config(&args, &config, stopped).await?);
+    results.write_if_requested(&args)
 }
 
 /// `bfb upload --file config.yaml`: YAML-config-driven upload.
@@ -60,21 +72,22 @@ async fn run_upload(
         args.shard_key = Some(sharding.key.clone());
     }
 
+    let mut results = BenchmarkResults::new(&args, Some(upload_args.file.clone()));
+
     if !args.skip_create && !args.skip_setup {
         collection::recreate_collection_from_config(&config, &args, stopped.clone()).await?;
     }
 
     if !args.skip_upload && !args.skip_setup {
-        upload::upload_with_config(&args, &config, stopped.clone()).await?;
+        results.results.upload =
+            Some(upload::upload_with_config(&args, &config, stopped.clone()).await?);
     }
 
     if !args.skip_wait_index && !args.skip_setup {
-        println!("Waiting for index to be ready...");
-        let wait_time = collection::wait_index(&args, stopped.clone()).await?;
-        println!("Index ready in {wait_time} seconds");
+        results.results.index = Some(run_wait_index(&args, stopped.clone()).await?);
     }
 
-    Ok(())
+    results.write_if_requested(&args)
 }
 
 async fn run_benchmark(args: Args, stopped: Arc<AtomicBool>) -> Result<()> {
@@ -90,29 +103,29 @@ async fn run_benchmark(args: Args, stopped: Arc<AtomicBool>) -> Result<()> {
         println!("Ignoring `exact` flag because `search_quality` is also enabled!");
     }
 
+    let mut results = BenchmarkResults::new(&args, None);
+
     if !args.skip_create && !args.skip_setup {
         collection::recreate_collection(&args, stopped.clone()).await?;
     }
 
     if !args.skip_upload && !args.skip_setup {
-        upload::upload_data(&args, stopped.clone()).await?;
+        results.results.upload = Some(upload::upload_data(&args, stopped.clone()).await?);
     }
 
     if !args.skip_wait_index && !args.skip_setup {
-        println!("Waiting for index to be ready...");
-        let wait_time = collection::wait_index(&args, stopped.clone()).await?;
-        println!("Index ready in {wait_time} seconds");
+        results.results.index = Some(run_wait_index(&args, stopped.clone()).await?);
     }
 
     if args.search || args.search_quality {
-        query::search(&args, stopped.clone()).await?;
+        results.results.search = Some(query::search(&args, stopped.clone()).await?);
     }
 
     if args.scroll {
-        query::scroll(&args, stopped.clone()).await?;
+        results.results.scroll = Some(query::scroll(&args, stopped.clone()).await?);
     }
 
-    Ok(())
+    results.write_if_requested(&args)
 }
 
 /// Parse command line arguments with shell completion installation support

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,12 +10,13 @@ use crate::args::Args;
 use crate::client::create_clients;
 use crate::config::search::SearchConfig;
 use crate::generators::random::UUID_PAYLOAD_KEY;
+use crate::results::QueryPhase;
 use crate::scroll::ScrollProcessor;
 use crate::search::ConfigSearchProcessor;
 use crate::search::SearchProcessor;
 use crate::stats::process;
 
-pub async fn search(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
+pub async fn search(args: &Args, stopped: Arc<AtomicBool>) -> Result<QueryPhase> {
     let clients = create_clients(args)?;
     let uuids = get_uuids(args, &clients[0]).await?;
 
@@ -28,13 +29,13 @@ pub async fn search_with_config(
     args: &Args,
     config: &SearchConfig,
     stopped: Arc<AtomicBool>,
-) -> Result<()> {
+) -> Result<QueryPhase> {
     let clients = create_clients(args)?;
     let searcher = ConfigSearchProcessor::new(args.clone(), config, stopped.clone(), clients)?;
     process(args, stopped, searcher).await
 }
 
-pub async fn scroll(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
+pub async fn scroll(args: &Args, stopped: Arc<AtomicBool>) -> Result<QueryPhase> {
     let clients = create_clients(args)?;
     let uuids = get_uuids(args, &clients[0]).await?;
 

--- a/src/results.rs
+++ b/src/results.rs
@@ -110,7 +110,7 @@ pub struct QueryPhase {
     pub precision: Option<PrecisionSummary>,
 }
 
-/// Distribution of a timing series. Percentiles use nearest-rank on sorted data.
+/// Distribution of a timing series. Percentiles use the legacy `index = floor(n * q)` rule on sorted data (upper-median for even `n`).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Summary {
     pub min: f32,

--- a/src/results.rs
+++ b/src/results.rs
@@ -13,10 +13,39 @@ use crate::args::Args;
 use crate::processor::Timing;
 
 /// Top-level document: `{ config: {...}, results: {...} }`.
+///
+/// For backward compatibility it also carries the pre-`results` top-level
+/// timing arrays; see [`LegacySearcherResults`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BenchmarkResults {
     pub config: RunConfig,
     pub results: PhaseResults,
+    /// Deprecated mirror of the last query phase. Flattened to the top level.
+    #[serde(flatten)]
+    pub legacy: Option<LegacySearcherResults>,
+}
+
+/// The shape `--json` emitted before the `{config, results}` document existed:
+/// three bare top-level arrays, written by whichever query phase ran last.
+///
+/// Kept so existing consumers (`jq '.rps'`, `jq '.server_timings'`) keep
+/// working. Prefer `results.search` / `results.scroll`; this will be removed in
+/// a future release.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LegacySearcherResults {
+    pub server_timings: Vec<f32>,
+    pub rps: Vec<f32>,
+    pub full_timings: Vec<f32>,
+}
+
+impl LegacySearcherResults {
+    fn from_phase(phase: &QueryPhase) -> Self {
+        LegacySearcherResults {
+            server_timings: phase.server_timings.clone(),
+            rps: phase.rps.clone(),
+            full_timings: phase.full_timings.clone(),
+        }
+    }
 }
 
 /// Echo of the run's parameters, so a results file is self-describing.
@@ -162,14 +191,30 @@ impl BenchmarkResults {
                 config_file,
             },
             results: PhaseResults::default(),
+            legacy: None,
         }
     }
 
+    /// Mirror the last query phase into the deprecated top-level fields.
+    ///
+    /// Pre-`results` each `process()` call rewrote the whole file, so a run with
+    /// both `--search` and `--scroll` left *scroll*'s numbers at the top level.
+    /// Reproduce that precedence rather than inventing new semantics.
+    fn populate_legacy_fields(&mut self) {
+        let last_phase = self
+            .results
+            .scroll
+            .as_ref()
+            .or(self.results.search.as_ref());
+        self.legacy = last_phase.map(LegacySearcherResults::from_phase);
+    }
+
     /// Write the document to `--json <path>`, if the flag was given.
-    pub fn write_if_requested(&self, args: &Args) -> Result<()> {
+    pub fn write_if_requested(&mut self, args: &Args) -> Result<()> {
         let Some(path) = args.json.as_ref() else {
             return Ok(());
         };
+        self.populate_legacy_fields();
         println!("--- Writing results to json file ---");
         let file =
             File::create(path).with_context(|| format!("failed to create results file {path}"))?;
@@ -240,9 +285,22 @@ mod tests {
         assert_eq!(json, r#"{"index":{"wait_secs":1.5}}"#);
     }
 
-    #[test]
-    fn document_roundtrips() {
-        let doc = BenchmarkResults {
+    /// A query phase whose series are distinguishable by `marker`.
+    fn phase(marker: f32) -> QueryPhase {
+        QueryPhase {
+            duration_secs: 2.0,
+            server_timings: vec![marker],
+            full_timings: vec![marker + 1.0],
+            rps: vec![marker + 2.0],
+            qps: vec![marker + 3.0],
+            server_time: Summary::from_sorted(&timings(&[marker])),
+            request_time: None,
+            precision: PrecisionSummary::new(vec![1.0]),
+        }
+    }
+
+    fn doc(results: PhaseResults) -> BenchmarkResults {
+        BenchmarkResults {
             config: RunConfig {
                 bfb_version: "0.1.1".into(),
                 collection_name: "benchmark".into(),
@@ -253,27 +311,82 @@ mod tests {
                 rps: None,
                 config_file: Some("c.yaml".into()),
             },
-            results: PhaseResults {
-                upload: Some(UploadPhase::new(1.0, 100)),
-                index: Some(IndexPhase { wait_secs: 0.5 }),
-                search: Some(QueryPhase {
-                    duration_secs: 2.0,
-                    server_timings: vec![1.0],
-                    full_timings: vec![2.0],
-                    rps: vec![50.0],
-                    qps: vec![50.0],
-                    server_time: Summary::from_sorted(&timings(&[1.0])),
-                    request_time: None,
-                    precision: PrecisionSummary::new(vec![1.0]),
-                }),
-                scroll: None,
-            },
-        };
+            results,
+            legacy: None,
+        }
+    }
+
+    fn to_value(doc: &BenchmarkResults) -> serde_json::Value {
+        serde_json::from_str(&serde_json::to_string(doc).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn document_roundtrips() {
+        let mut doc = doc(PhaseResults {
+            upload: Some(UploadPhase::new(1.0, 100)),
+            index: Some(IndexPhase { wait_secs: 0.5 }),
+            search: Some(phase(1.0)),
+            scroll: None,
+        });
+        doc.populate_legacy_fields();
 
         let json = serde_json::to_string(&doc).unwrap();
         assert_eq!(
             serde_json::from_str::<BenchmarkResults>(&json).unwrap(),
             doc
         );
+    }
+
+    #[test]
+    fn legacy_fields_mirror_search_at_the_top_level() {
+        let mut doc = doc(PhaseResults {
+            search: Some(phase(1.0)),
+            ..Default::default()
+        });
+        doc.populate_legacy_fields();
+        let json = to_value(&doc);
+
+        // The pre-M1 `jq` paths must still resolve...
+        assert_eq!(json["server_timings"], serde_json::json!([1.0]));
+        assert_eq!(json["full_timings"], serde_json::json!([2.0]));
+        assert_eq!(json["rps"], serde_json::json!([3.0]));
+        // ...and agree with the new nested location.
+        assert_eq!(
+            json["results"]["search"]["server_timings"],
+            json["server_timings"]
+        );
+    }
+
+    #[test]
+    fn scroll_wins_over_search_at_the_top_level() {
+        // Pre-M1 each phase rewrote the whole file, so scroll (which runs last)
+        // clobbered search. Preserve that precedence.
+        let mut doc = doc(PhaseResults {
+            search: Some(phase(1.0)),
+            scroll: Some(phase(10.0)),
+            ..Default::default()
+        });
+        doc.populate_legacy_fields();
+
+        assert_eq!(doc.legacy.as_ref().unwrap().server_timings, vec![10.0]);
+        // The nested phases still each keep their own numbers.
+        assert_eq!(
+            doc.results.search.as_ref().unwrap().server_timings,
+            vec![1.0]
+        );
+    }
+
+    #[test]
+    fn upload_only_run_emits_no_legacy_fields() {
+        let mut doc = doc(PhaseResults {
+            upload: Some(UploadPhase::new(1.0, 100)),
+            index: Some(IndexPhase { wait_secs: 0.5 }),
+            ..Default::default()
+        });
+        doc.populate_legacy_fields();
+
+        let json = to_value(&doc);
+        assert!(json.get("server_timings").is_none());
+        assert!(json.get("rps").is_none());
     }
 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -5,6 +5,7 @@
 //! instead of scraping stdout or timing phases from the shell.
 
 use std::fs::File;
+use std::io::{BufWriter, Write};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -218,7 +219,13 @@ impl BenchmarkResults {
         println!("--- Writing results to json file ---");
         let file =
             File::create(path).with_context(|| format!("failed to create results file {path}"))?;
-        serde_json::to_writer_pretty(file, self)
+        // serde_json writes straight through: unbuffered, a 1M-request series
+        // takes ~45 s here, one syscall per token.
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, self)
+            .with_context(|| format!("failed to write results to {path}"))?;
+        writer
+            .flush()
             .with_context(|| format!("failed to write results to {path}"))?;
         println!("Results written to {path}");
         Ok(())

--- a/src/results.rs
+++ b/src/results.rs
@@ -1,0 +1,279 @@
+//! The unified benchmark results document written by `--json`.
+//!
+//! One typed `{config, results}` object covering *every* phase of a run —
+//! upload, index wait, search, scroll — so consumers read BFB's own output
+//! instead of scraping stdout or timing phases from the shell.
+
+use std::fs::File;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::args::Args;
+use crate::processor::Timing;
+
+/// Top-level document: `{ config: {...}, results: {...} }`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BenchmarkResults {
+    pub config: RunConfig,
+    pub results: PhaseResults,
+}
+
+/// Echo of the run's parameters, so a results file is self-describing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RunConfig {
+    pub bfb_version: String,
+    pub collection_name: String,
+    pub num_vectors: usize,
+    pub batch_size: usize,
+    pub parallel: usize,
+    pub threads: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rps: Option<f64>,
+    /// Path of the YAML config driving `bfb upload` / `bfb search`, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_file: Option<String>,
+}
+
+/// One entry per phase. A phase that did not run is omitted.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PhaseResults {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upload: Option<UploadPhase>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<IndexPhase>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search: Option<QueryPhase>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scroll: Option<QueryPhase>,
+}
+
+/// M2: upload wall time and throughput.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UploadPhase {
+    pub duration_secs: f64,
+    /// Points actually sent (may be < requested if the run was interrupted).
+    pub num_points: usize,
+    pub points_per_sec: f64,
+}
+
+/// M2: time spent waiting for the collection to report a green index.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IndexPhase {
+    pub wait_secs: f64,
+}
+
+/// A search or scroll phase: latency/throughput series plus their summaries.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct QueryPhase {
+    pub duration_secs: f64,
+    /// Per-request latency reported by the server, in seconds.
+    pub server_timings: Vec<f32>,
+    /// End-to-end per-request latency, in seconds.
+    pub full_timings: Vec<f32>,
+    pub rps: Vec<f32>,
+    pub qps: Vec<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_time: Option<Summary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_time: Option<Summary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub precision: Option<PrecisionSummary>,
+}
+
+/// Distribution of a timing series. Percentiles use nearest-rank on sorted data.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct Summary {
+    pub min: f32,
+    pub avg: f64,
+    pub p50: f32,
+    pub p95: f32,
+    pub max: f32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct PrecisionSummary {
+    pub avg: f32,
+    pub p50: f32,
+}
+
+impl Summary {
+    /// Summarize `values`, which **must already be sorted** by `value` ascending.
+    /// Returns `None` for an empty series.
+    pub fn from_sorted(values: &[Timing]) -> Option<Self> {
+        let first = values.first()?;
+        Some(Summary {
+            min: first.value,
+            avg: values.iter().map(|x| x.value as f64).sum::<f64>() / values.len() as f64,
+            p50: percentile(values, 0.50),
+            p95: percentile(values, 0.95),
+            max: values.last().expect("non-empty").value,
+        })
+    }
+}
+
+/// Nearest-rank percentile of a sorted, non-empty series.
+fn percentile(sorted: &[Timing], q: f32) -> f32 {
+    let index = ((sorted.len() as f32 * q) as usize).min(sorted.len() - 1);
+    sorted[index].value
+}
+
+impl PrecisionSummary {
+    /// Summarize precision/recall samples. Sorts a copy; returns `None` if empty.
+    pub fn new(mut precisions: Vec<f32>) -> Option<Self> {
+        if precisions.is_empty() {
+            return None;
+        }
+        let avg = precisions.iter().sum::<f32>() / precisions.len() as f32;
+        precisions.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let index = ((precisions.len() as f32 * 0.50) as usize).min(precisions.len() - 1);
+        Some(PrecisionSummary {
+            avg,
+            p50: precisions[index],
+        })
+    }
+}
+
+impl UploadPhase {
+    pub fn new(duration_secs: f64, num_points: usize) -> Self {
+        UploadPhase {
+            duration_secs,
+            num_points,
+            points_per_sec: if duration_secs > 0.0 {
+                num_points as f64 / duration_secs
+            } else {
+                0.0
+            },
+        }
+    }
+}
+
+impl BenchmarkResults {
+    pub fn new(args: &Args, config_file: Option<String>) -> Self {
+        BenchmarkResults {
+            config: RunConfig {
+                bfb_version: env!("CARGO_PKG_VERSION").to_string(),
+                collection_name: args.collection_name.clone(),
+                num_vectors: args.num_vectors_or_default(),
+                batch_size: args.batch_size,
+                parallel: args.parallel,
+                threads: args.threads,
+                rps: args.rps,
+                config_file,
+            },
+            results: PhaseResults::default(),
+        }
+    }
+
+    /// Write the document to `--json <path>`, if the flag was given.
+    pub fn write_if_requested(&self, args: &Args) -> Result<()> {
+        let Some(path) = args.json.as_ref() else {
+            return Ok(());
+        };
+        println!("--- Writing results to json file ---");
+        let file =
+            File::create(path).with_context(|| format!("failed to create results file {path}"))?;
+        serde_json::to_writer_pretty(file, self)
+            .with_context(|| format!("failed to write results to {path}"))?;
+        println!("Results written to {path}");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn timings(values: &[f32]) -> Vec<Timing> {
+        values
+            .iter()
+            .map(|&value| Timing {
+                delay_millis: 0,
+                value,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn summary_of_empty_series_is_none() {
+        assert!(Summary::from_sorted(&[]).is_none());
+        assert!(PrecisionSummary::new(vec![]).is_none());
+    }
+
+    #[test]
+    fn summary_reports_distribution() {
+        let s = Summary::from_sorted(&timings(&[1.0, 2.0, 3.0, 4.0])).unwrap();
+        assert_eq!(s.min, 1.0);
+        assert_eq!(s.max, 4.0);
+        assert_eq!(s.avg, 2.5);
+        assert_eq!(s.p50, 3.0); // nearest-rank: index 2
+    }
+
+    #[test]
+    fn summary_of_single_sample_never_indexes_past_the_end() {
+        let s = Summary::from_sorted(&timings(&[7.0])).unwrap();
+        assert_eq!((s.min, s.p50, s.p95, s.max), (7.0, 7.0, 7.0, 7.0));
+    }
+
+    #[test]
+    fn precision_summary_sorts_before_taking_median() {
+        let p = PrecisionSummary::new(vec![0.9, 0.1, 0.5]).unwrap();
+        assert_eq!(p.p50, 0.5);
+        assert!((p.avg - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn upload_phase_derives_throughput() {
+        let u = UploadPhase::new(2.0, 1000);
+        assert_eq!(u.points_per_sec, 500.0);
+        // A zero-length run must not produce inf/NaN.
+        assert_eq!(UploadPhase::new(0.0, 10).points_per_sec, 0.0);
+    }
+
+    #[test]
+    fn skipped_phases_are_omitted_from_json() {
+        let results = PhaseResults {
+            index: Some(IndexPhase { wait_secs: 1.5 }),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&results).unwrap();
+        assert_eq!(json, r#"{"index":{"wait_secs":1.5}}"#);
+    }
+
+    #[test]
+    fn document_roundtrips() {
+        let doc = BenchmarkResults {
+            config: RunConfig {
+                bfb_version: "0.1.1".into(),
+                collection_name: "benchmark".into(),
+                num_vectors: 100,
+                batch_size: 8,
+                parallel: 2,
+                threads: 4,
+                rps: None,
+                config_file: Some("c.yaml".into()),
+            },
+            results: PhaseResults {
+                upload: Some(UploadPhase::new(1.0, 100)),
+                index: Some(IndexPhase { wait_secs: 0.5 }),
+                search: Some(QueryPhase {
+                    duration_secs: 2.0,
+                    server_timings: vec![1.0],
+                    full_timings: vec![2.0],
+                    rps: vec![50.0],
+                    qps: vec![50.0],
+                    server_time: Summary::from_sorted(&timings(&[1.0])),
+                    request_time: None,
+                    precision: PrecisionSummary::new(vec![1.0]),
+                }),
+                scroll: None,
+            },
+        };
+
+        let json = serde_json::to_string(&doc).unwrap();
+        assert_eq!(
+            serde_json::from_str::<BenchmarkResults>(&json).unwrap(),
+            doc
+        );
+    }
+}

--- a/src/results.rs
+++ b/src/results.rs
@@ -141,7 +141,7 @@ impl Summary {
     }
 }
 
-/// Nearest-rank percentile of a sorted, non-empty series.
+/// Percentile of a sorted, non-empty series using the legacy `index = floor(n * q)` rule.
 fn percentile(sorted: &[Timing], q: f32) -> f32 {
     let index = ((sorted.len() as f32 * q) as usize).min(sorted.len() - 1);
     sorted[index].value

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,12 +1,10 @@
-use std::fs::File;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use futures::stream::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
-use serde::{Deserialize, Serialize};
 use tokio::join;
 
 use futures::Stream;
@@ -14,6 +12,7 @@ use tokio_stream::wrappers::IntervalStream;
 
 use crate::args::Args;
 use crate::processor::{Processor, Timing};
+use crate::results::{PrecisionSummary, QueryPhase, Summary};
 use crate::save_jsonl::save_timings_as_jsonl;
 
 /// Build a stream that will emit a unit value at the given frequency
@@ -35,38 +34,28 @@ pub(crate) fn throttler(hz: Option<f32>) -> Box<dyn Stream<Item = ()> + Unpin> {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct SearcherResults {
-    pub server_timings: Vec<f32>,
-    pub rps: Vec<f32>,
-    pub full_timings: Vec<f32>,
-}
-
-pub fn write_to_json(path: &String, results: SearcherResults) {
-    let mut file = File::create(path).unwrap();
-    serde_json::to_writer(&mut file, &results).unwrap();
-    println!("Search results written to {path}");
-}
-
-pub fn print_stats(args: &Args, values: &mut [Timing], metric_name: &str, show_percentiles: bool) {
+/// Sort `values`, print their distribution, and return it as a [`Summary`].
+/// Returns `None` for an empty series.
+pub fn print_stats(
+    args: &Args,
+    values: &mut [Timing],
+    metric_name: &str,
+    show_percentiles: bool,
+) -> Option<Summary> {
     if values.is_empty() {
-        return;
+        return None;
     }
     // sort values in ascending order
     values.sort_unstable_by(|a, b| a.value.partial_cmp(&b.value).unwrap());
 
-    let avg_time = values.iter().map(|x| x.value as f64).sum::<f64>() / values.len() as f64;
-    let min_time = values.first().unwrap().value;
-    let max_time = values.last().unwrap().value;
-    let p50_time = values[(values.len() as f32 * 0.50) as usize].value;
+    let summary = Summary::from_sorted(values).expect("non-empty");
 
-    println!("Min {metric_name}: {min_time}");
-    println!("Avg {metric_name}: {avg_time}");
-    println!("Median {metric_name}: {p50_time}");
+    println!("Min {metric_name}: {}", summary.min);
+    println!("Avg {metric_name}: {}", summary.avg);
+    println!("Median {metric_name}: {}", summary.p50);
 
     if show_percentiles {
-        let p95_time = values[(values.len() as f32 * 0.95) as usize].value;
-        println!("p95 {metric_name}: {p95_time}");
+        println!("p95 {metric_name}: {}", summary.p95);
 
         for digits in 2..=args.p9 {
             let factor = 1.0 - 0.1f64.powf(digits as f64);
@@ -77,14 +66,17 @@ pub fn print_stats(args: &Args, values: &mut [Timing], metric_name: &str, show_p
         }
     }
 
-    println!("Max {metric_name}: {max_time}");
+    println!("Max {metric_name}: {}", summary.max);
+    Some(summary)
 }
 
+/// Run `processor` to completion and return the phase's measurements.
 pub async fn process<P: Processor + Sync>(
     args: &Args,
     stopped: Arc<AtomicBool>,
     processor: P,
-) -> Result<()> {
+) -> Result<QueryPhase> {
+    let started = Instant::now();
     let batch_size = processor.get_batch_size();
     let batch_count = args.num_vectors_or_default().div_ceil(batch_size);
 
@@ -127,13 +119,14 @@ pub async fn process<P: Processor + Sync>(
     } else {
         progress_bar.finish();
     }
+    let duration_secs = started.elapsed().as_secs_f64();
 
     let mut full_timings = processor.full_timings();
     println!("--- Request timings ---");
-    print_stats(args, &mut full_timings, "request time", true);
+    let request_time = print_stats(args, &mut full_timings, "request time", true);
     let mut server_timings = processor.server_timings();
     println!("--- Server timings ---");
-    print_stats(args, &mut server_timings, "server time", true);
+    let server_time = print_stats(args, &mut server_timings, "server time", true);
 
     let mut rps = processor.rps();
     println!("--- RPS ---");
@@ -142,29 +135,23 @@ pub async fn process<P: Processor + Sync>(
     println!("--- QPS ---");
     print_stats(args, &mut qps, "qps", false);
 
-    let precisions = processor.precisions();
-    if !precisions.is_empty() {
+    let precision = PrecisionSummary::new(processor.precisions());
+    if let Some(precision) = &precision {
         println!("--- Precision ---");
-        let avg_precision = precisions.iter().sum::<f32>() / precisions.len() as f32;
-        println!("Avg precision@10: {avg_precision}");
-
-        let mut sorted_precisions = precisions;
-        sorted_precisions.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
-        let p50_time = sorted_precisions[(sorted_precisions.len() as f32 * 0.50) as usize];
-        println!("Median precision@10: {p50_time}");
+        println!("Avg precision@10: {}", precision.avg);
+        println!("Median precision@10: {}", precision.p50);
     }
 
-    if let Some(json) = args.json.as_ref() {
-        println!("--- Writing results to json file ---");
-        write_to_json(
-            json,
-            SearcherResults {
-                server_timings: server_timings.iter().map(|x| x.value).collect(),
-                rps: rps.iter().map(|x| x.value).collect(),
-                full_timings: full_timings.iter().map(|x| x.value).collect(),
-            },
-        );
-    }
+    let phase = QueryPhase {
+        duration_secs,
+        server_timings: server_timings.iter().map(|x| x.value).collect(),
+        full_timings: full_timings.iter().map(|x| x.value).collect(),
+        rps: rps.iter().map(|x| x.value).collect(),
+        qps: qps.iter().map(|x| x.value).collect(),
+        server_time,
+        request_time,
+        precision,
+    };
 
     if let Some(jsonl_path) = &args.jsonl_searches {
         save_timings_as_jsonl(
@@ -186,7 +173,7 @@ pub async fn process<P: Processor + Sync>(
         )?;
     }
 
-    Ok(())
+    Ok(phase)
 }
 
 /// Process requests using fixed parallelism (original behavior)
@@ -316,36 +303,36 @@ async fn process_with_rps<P: Processor + Sync>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
-    #[test]
-    fn test_searcher_results_serde_roundtrip() {
-        let results = SearcherResults {
-            server_timings: vec![1.0, 2.5, 3.7],
-            rps: vec![100.0, 200.0],
-            full_timings: vec![0.5, 1.5, 2.5, 3.5],
-        };
-
-        let json = serde_json::to_string(&results).unwrap();
-        let deserialized: SearcherResults = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(results.server_timings, deserialized.server_timings);
-        assert_eq!(results.rps, deserialized.rps);
-        assert_eq!(results.full_timings, deserialized.full_timings);
+    fn timings(values: &[f32]) -> Vec<Timing> {
+        values
+            .iter()
+            .map(|&value| Timing {
+                delay_millis: 0,
+                value,
+            })
+            .collect()
     }
 
     #[test]
-    fn test_searcher_results_empty() {
-        let results = SearcherResults {
-            server_timings: vec![],
-            rps: vec![],
-            full_timings: vec![],
-        };
+    fn print_stats_summarizes_and_sorts_in_place() {
+        let args = Args::parse_from(["bfb"]);
+        let mut values = timings(&[3.0, 1.0, 2.0, 4.0]);
 
-        let json = serde_json::to_string(&results).unwrap();
-        let deserialized: SearcherResults = serde_json::from_str(&json).unwrap();
+        let summary = print_stats(&args, &mut values, "request time", true).unwrap();
 
-        assert!(deserialized.server_timings.is_empty());
-        assert!(deserialized.rps.is_empty());
-        assert!(deserialized.full_timings.is_empty());
+        assert_eq!(summary.min, 1.0);
+        assert_eq!(summary.max, 4.0);
+        assert_eq!(summary.avg, 2.5);
+        // The caller relies on `print_stats` leaving the series sorted.
+        let sorted: Vec<_> = values.iter().map(|t| t.value).collect();
+        assert_eq!(sorted, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn print_stats_of_empty_series_is_none() {
+        let args = Args::parse_from(["bfb"]);
+        assert!(print_stats(&args, &mut [], "request time", true).is_none());
     }
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use futures::stream::StreamExt;
@@ -13,11 +13,12 @@ use crate::client::get_config;
 use crate::config::UploadConfig;
 use crate::fbin_reader::FBinReader;
 use crate::generators::{ConfigGenerator, LegacyGenerator, PointGenerator};
+use crate::results::UploadPhase;
 use crate::stats::throttler;
 use crate::upsert::UpsertProcessor;
 
 /// Legacy flag-driven upload.
-pub async fn upload_data(args: &Args, stopped: Arc<AtomicBool>) -> Result<()> {
+pub async fn upload_data(args: &Args, stopped: Arc<AtomicBool>) -> Result<UploadPhase> {
     let reader = args
         .fbin
         .as_ref()
@@ -31,7 +32,7 @@ pub async fn upload_with_config(
     args: &Args,
     config: &UploadConfig,
     stopped: Arc<AtomicBool>,
-) -> Result<()> {
+) -> Result<UploadPhase> {
     let generator = Arc::new(ConfigGenerator::new(config)?);
     run_upload(args, stopped, generator).await
 }
@@ -40,7 +41,7 @@ async fn run_upload(
     args: &Args,
     stopped: Arc<AtomicBool>,
     generator: Arc<dyn PointGenerator>,
-) -> Result<()> {
+) -> Result<UploadPhase> {
     let mut clients = Vec::new();
     for config in get_config(args) {
         clients.push(qdrant_client::Qdrant::new(config)?);
@@ -74,12 +75,17 @@ async fn run_upload(
         generator,
     );
 
-    let num_batches = args.num_vectors_or_default().div_ceil(args.batch_size);
+    let num_vectors = args.num_vectors_or_default();
+    let num_batches = num_vectors.div_ceil(args.batch_size);
 
     if stopped.load(Ordering::Relaxed) {
         sent_bar_arc.abandon();
-        return Ok(());
+        return Ok(UploadPhase::new(0.0, 0));
     }
+
+    // Time only the upload itself: client setup and generator construction
+    // (which may download a dataset) are not part of upload throughput.
+    let started = Instant::now();
 
     // Use RPS mode if --rps is set, otherwise use parallel mode
     if let Some(target_rps) = args.rps {
@@ -96,6 +102,8 @@ async fn run_upload(
         upload_with_parallel(args, stopped.clone(), &upserter, &sent_bar_arc, num_batches).await?;
     }
 
+    let duration_secs = started.elapsed().as_secs_f64();
+
     if stopped.load(Ordering::Relaxed) {
         sent_bar_arc.abandon();
     } else {
@@ -104,7 +112,16 @@ async fn run_upload(
 
     upserter.save_data();
 
-    Ok(())
+    // The bar advances a whole batch at a time, so the final batch can push it
+    // past the requested count; report what was actually asked for.
+    let num_points = (sent_bar_arc.position() as usize).min(num_vectors);
+    let phase = UploadPhase::new(duration_secs, num_points);
+    println!(
+        "Uploaded {} points in {:.3} s ({:.0} points/s)",
+        phase.num_points, phase.duration_secs, phase.points_per_sec
+    );
+
+    Ok(phase)
 }
 
 /// Upload data using fixed parallelism (original behavior)


### PR DESCRIPTION


--json previously wrote only search timings — a bare {server_timings, rps, full_timings} — and only from the search/scroll path. Upload throughput and index-wait time were printed to stdout and nowhere else, so callers timed the upload phase with date and scraped the rest. This makes BFB the source of truth for its own measurements.

--json <path> now writes one typed document covering the whole run: a config echo (version, collection, point count, batch size, parallelism, threads, rps, YAML config path) and a results section per phase that actually executed.

```
{
  "config": { "bfb_version": "0.1.1", "collection_name": "benchmark", "num_vectors": 1000000, ... },
  "results": {
    "upload": { "duration_secs": 57.8, "num_points": 1000000, "points_per_sec": 17301.0 },
    "index":  { "wait_secs": 12.4 },
    "search": {
      "duration_secs": 30.1,
      "server_timings": [...], "full_timings": [...], "rps": [...], "qps": [...],
      "server_time":  { "min": ..., "avg": ..., "p50": ..., "p95": ..., "max": ... },
      "request_time": { ... },
       "precision": { "avg": 0.98, "p50": 1.0 }
    }
  }             
}
```

What's new
- Upload phase (duration_secs, num_points, points_per_sec) — timed around the upload loop only, so client setup and dataset download don't distort throughput.
- Index phase (wait_secs) — wait_index's return value, previously only println!ed.
- Per-phase duration_secs for search and scroll.
- Timing summaries (min/avg/p50/p95/max) alongside the raw series; print_stats now returns the summary it prints rather than duplicating the math.
- Works on all three modes: bfb upload --file, bfb search --file, and legacy flag-driven runs. Phases that didn't run are omitted, and precision appears only when accuracy was measured.

No breaking changes. One additive difference is that an upload-only run now writes a results file where before it wrote none. 