### PR TITLE
feat: bfb scroll sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,16 @@ collection so it can be timed and reported independently:
 bfb scroll --file examples/scroll-config.yaml -n 50k -p 8 --json scroll.json
 ```
 
-The YAML describes the *shape* of scroll requests: the collection, and the
-payload filters to scroll by. One template is picked at random per request, with
-fresh random filter values — so a single run can compare filtered against
-unfiltered:
+The YAML describes the *shape* of scroll requests: how to traverse the
+collection, and the payload filters to scroll by. One template is picked at
+random per request, with fresh random filter values — so a single run can
+compare filtered against unfiltered:
 
 ```yaml
 collection:
   name: benchmark
+
+mode: scroll             # scroll | sequential | sample
 
 requests:
   - filters: []          # unfiltered
@@ -133,6 +135,14 @@ requests:
         type: keyword
         source: { type: random, cardinality: 100 }
 ```
+
+`mode` picks the traversal, and is orthogonal to `filters`:
+
+| mode | request |
+| --- | --- |
+| `scroll` | first page matching the filter; every request starts at the top (default) |
+| `sequential` | cursor walk — each request resumes from the previous page, wrapping once exhausted. One walk per `-p` worker |
+| `sample` | a vector-less `query` with `sample: random` |
 
 Filter entries use the same payload `type` / `source` vocabulary as the upload
 and search configs. The CLI still controls *how* the benchmark runs (`-n`, `-p`,

--- a/README.md
+++ b/README.md
@@ -108,6 +108,40 @@ scheme (point id == dataset row index), which is what `bfb upload` does for
 `id: integer` collections. See
 [`examples/search-dataset-accuracy.yaml`](examples/search-dataset-accuracy.yaml).
 
+### `scroll` — run a scroll workload as its own phase
+
+The same workload as the legacy `--scroll` flag, runnable on an existing
+collection so it can be timed and reported independently:
+
+```bash
+bfb scroll --file examples/scroll-config.yaml -n 50k -p 8 --json scroll.json
+```
+
+The YAML describes the *shape* of scroll requests: the collection, and the
+payload filters to scroll by. One template is picked at random per request, with
+fresh random filter values — so a single run can compare filtered against
+unfiltered:
+
+```yaml
+collection:
+  name: benchmark
+
+requests:
+  - filters: []          # unfiltered
+  - filters:
+      - name: color
+        type: keyword
+        source: { type: random, cardinality: 100 }
+```
+
+Filter entries use the same payload `type` / `source` vocabulary as the upload
+and search configs. The CLI still controls *how* the benchmark runs (`-n`, `-p`,
+`--search-limit`, `--search-with-payload`, …). Results land under
+`results.scroll`. See [`examples/scroll-config.yaml`](examples/scroll-config.yaml).
+
+The flag-driven path (`bfb --scroll --keywords 100 …`) is still available when
+you prefer flat CLI flags over a YAML file.
+
 ### `schema` — print the upload-config file schema
 
 Print an annotated YAML reference enumerating every option accepted by an

--- a/examples/scroll-config.yaml
+++ b/examples/scroll-config.yaml
@@ -1,0 +1,37 @@
+# Example bfb scroll config.
+#
+#   bfb scroll --file examples/scroll-config.yaml -n 50k -p 8 --search-limit 10
+#
+# The YAML describes the *shape* of scroll requests (collection + payload
+# filters); the CLI flags control *how* the benchmark runs (request count,
+# parallelism, limit, …). One template is picked at random per request.
+#
+# Pair this with examples/upload-config.yaml: upload first, then scroll the same
+# collection. The flag-driven path (`bfb --scroll --keywords 100`) is unchanged.
+
+collection:
+  name: benchmark
+
+requests:
+  # Unfiltered scroll over the whole collection.
+  - filters: []
+
+  # Scroll points matching a random `color` keyword.
+  - filters:
+      - name: color
+        type: keyword
+        source:
+          type: random
+          cardinality: 100
+
+  # Two conditions, ANDed. The integer condition is one-sided — `price >= x`,
+  # where x is drawn at random from [min, max) per request — not a bounded
+  # [min, max] range. Widen the gap between min and max to make the filter more
+  # selective on average.
+  - filters:
+      - name: color
+        type: keyword
+        source: { type: random, cardinality: 100 }
+      - name: price
+        type: integer
+        source: { type: random, min: 0, max: 1000000 }

--- a/examples/scroll-config.yaml
+++ b/examples/scroll-config.yaml
@@ -12,6 +12,15 @@
 collection:
   name: benchmark
 
+# How a request traverses the collection. `mode` and `filters` are orthogonal:
+#
+#   scroll      fetch the first page matching the filter; every request starts
+#               at the top (default)
+#   sequential  walk the collection — each request resumes from the previous
+#               page's cursor, wrapping once exhausted. One walk per `-p` worker
+#   sample      a vector-less `query` with `sample: random`
+mode: scroll
+
 requests:
   # Unfiltered scroll over the whole collection.
   - filters: []

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -436,6 +436,15 @@ pub enum Command {
     /// `--search-batch-size`, `--uri`, …) still control *how* the benchmark runs.
     Search(SearchArgs),
 
+    /// Run a scroll workload against an existing collection.
+    ///
+    /// The same workload as the legacy `--scroll` flag, runnable as a phase of
+    /// its own so it can be timed and reported independently. The YAML file
+    /// defines the *shape* of scroll requests (which payload filters); the
+    /// runtime flags (`-n`, `--parallel`, `--search-limit`, …) still control
+    /// *how* the benchmark runs.
+    Scroll(ScrollArgs),
+
     /// Print the upload-config file schema: every option, its type, default,
     /// and allowed values, as an annotated YAML reference.
     Schema,
@@ -444,6 +453,13 @@ pub enum Command {
 #[derive(clap::Args, Debug, Clone)]
 pub struct SearchArgs {
     /// Path to the YAML search-request config file
+    #[clap(long)]
+    pub file: String,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct ScrollArgs {
+    /// Path to the YAML scroll config file
     #[clap(long)]
     pub file: String,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,7 @@
 pub mod collection;
 pub mod payload;
 pub mod schema;
+pub mod scroll;
 pub mod search;
 pub mod vector;
 

--- a/src/config/scroll.rs
+++ b/src/config/scroll.rs
@@ -1,0 +1,71 @@
+//! YAML scroll configuration for `bfb scroll --file config.yaml`.
+//!
+//! Describes only the *shape* of scroll requests (which collection, which
+//! payload filters). The *how* (number of requests, limit, parallelism, uri, …)
+//! stays on the CLI.
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::config::search::{FilterPayloadConfig, SearchCollectionConfig};
+
+/// Top-level document: `{ collection: { name }, requests: [ … ] }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScrollConfig {
+    pub collection: SearchCollectionConfig,
+    pub requests: Vec<ScrollRequestConfig>,
+}
+
+/// One scroll-request template. At benchmark time one is picked at random per
+/// request, with fresh random filter values.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScrollRequestConfig {
+    /// Payload conditions, ANDed together. Empty scrolls the whole collection.
+    #[serde(default)]
+    pub filters: Vec<FilterPayloadConfig>,
+}
+
+pub fn load(path: &str) -> Result<ScrollConfig> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read scroll config file {path}"))?;
+    let config: ScrollConfig = serde_yaml::from_str(&text)
+        .with_context(|| format!("failed to parse scroll config file {path}"))?;
+    config.validate()?;
+    Ok(config)
+}
+
+impl ScrollConfig {
+    pub fn validate(&self) -> Result<()> {
+        if self.requests.is_empty() {
+            bail!("scroll config must declare at least one entry under `requests`");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_filtered_and_unfiltered_templates() {
+        let config: ScrollConfig = serde_yaml::from_str(
+            "collection:\n  name: x\nrequests:\n  - filters: []\n  - filters:\n      - name: color\n        type: keyword\n        source: { type: random, cardinality: 100 }\n",
+        )
+        .unwrap();
+        config.validate().unwrap();
+
+        assert_eq!(config.collection.name, "x");
+        assert!(config.requests[0].filters.is_empty());
+        assert_eq!(config.requests[1].filters[0].name, "color");
+    }
+
+    #[test]
+    fn rejects_a_config_with_no_requests() {
+        let config: ScrollConfig =
+            serde_yaml::from_str("collection:\n  name: x\nrequests: []\n").unwrap();
+        assert!(config.validate().is_err());
+    }
+}

--- a/src/config/scroll.rs
+++ b/src/config/scroll.rs
@@ -9,11 +9,28 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::search::{FilterPayloadConfig, SearchCollectionConfig};
 
-/// Top-level document: `{ collection: { name }, requests: [ … ] }`.
+/// How a request traverses the collection. Orthogonal to `requests:` — any mode
+/// can be combined with any filter template.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ScrollMode {
+    /// Fetch the first page matching the filter; every request starts at the top.
+    #[default]
+    Scroll,
+    /// Walk the collection: each request resumes from the previous page's cursor,
+    /// wrapping to the start once exhausted.
+    Sequential,
+    /// Random sample: a `query` with `sample: random` and no vector.
+    Sample,
+}
+
+/// Top-level document: `{ collection: { name }, mode, requests: [ … ] }`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ScrollConfig {
     pub collection: SearchCollectionConfig,
+    #[serde(default)]
+    pub mode: ScrollMode,
     pub requests: Vec<ScrollRequestConfig>,
 }
 
@@ -58,6 +75,7 @@ mod tests {
         config.validate().unwrap();
 
         assert_eq!(config.collection.name, "x");
+        assert_eq!(config.mode, ScrollMode::Scroll);
         assert!(config.requests[0].filters.is_empty());
         assert_eq!(config.requests[1].filters[0].name, "color");
     }
@@ -67,5 +85,20 @@ mod tests {
         let config: ScrollConfig =
             serde_yaml::from_str("collection:\n  name: x\nrequests: []\n").unwrap();
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn parses_every_mode() {
+        for (text, expected) in [
+            ("sequential", ScrollMode::Sequential),
+            ("sample", ScrollMode::Sample),
+            ("scroll", ScrollMode::Scroll),
+        ] {
+            let config: ScrollConfig = serde_yaml::from_str(&format!(
+                "collection:\n  name: x\nmode: {text}\nrequests:\n  - filters: []\n"
+            ))
+            .unwrap();
+            assert_eq!(config.mode, expected);
+        }
     }
 }

--- a/src/generators/queries.rs
+++ b/src/generators/queries.rs
@@ -64,8 +64,181 @@ struct RequestState {
     /// Reference dataset used as the query source (dense or sparse).
     query_dataset: Option<QueryDataset>,
     sparse_zipf: Option<rand_distr::Zipf<f64>>,
+    filters: FilterGenerator,
+}
+
+/// Builds a random payload filter from a list of [`FilterPayloadConfig`].
+///
+/// Shared by `bfb search --file` and `bfb scroll --file`: the filter half of a
+/// request is the same in both, only the query half differs.
+pub struct FilterGenerator {
+    filters: Vec<FilterPayloadConfig>,
+    /// Parallel to `filters`; `Some` only for zipf-distributed text fields.
     text_zipf: Vec<Option<rand_distr::Zipf<f64>>>,
+    /// Parallel to `filters`; `Some` only for clustered geo fields.
     geo_clusters: Vec<Option<Vec<(f64, f64)>>>,
+}
+
+impl FilterGenerator {
+    pub fn new(filters: &[FilterPayloadConfig], rng: &mut impl Rng) -> Self {
+        FilterGenerator {
+            filters: filters.to_vec(),
+            text_zipf: filters.iter().map(Self::maybe_text_zipf).collect(),
+            geo_clusters: filters
+                .iter()
+                .map(|f| Self::maybe_geo_clusters(f, rng))
+                .collect(),
+        }
+    }
+
+    fn maybe_text_zipf(filter: &FilterPayloadConfig) -> Option<rand_distr::Zipf<f64>> {
+        (filter.kind == PayloadType::Text && filter.source.distribution == DistributionKind::Zipf)
+            .then(|| create_zipf(filter.source.vocab_size.unwrap_or(DEFAULT_VOCAB_SIZE)))
+    }
+
+    fn maybe_geo_clusters(
+        filter: &FilterPayloadConfig,
+        rng: &mut impl Rng,
+    ) -> Option<Vec<(f64, f64)>> {
+        (filter.kind == PayloadType::Geo && filter.source.kind == PayloadSourceKind::RandomClusters)
+            .then(|| {
+                let count = filter.source.clusters.unwrap_or(10);
+                (0..count)
+                    .map(|_| {
+                        (
+                            GEO_CENTER_LAT + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
+                            GEO_CENTER_LON + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
+                        )
+                    })
+                    .collect()
+            })
+    }
+
+    /// Materialize one random filter. `None` when no filters are configured.
+    pub fn build(&self, rng: &mut impl Rng) -> Option<Filter> {
+        if self.filters.is_empty() {
+            return None;
+        }
+
+        let mut filter = Filter {
+            should: vec![],
+            must: vec![],
+            must_not: vec![],
+            min_should: None,
+        };
+
+        for (i, fp) in self.filters.iter().enumerate() {
+            let src = &fp.source;
+            match fp.kind {
+                PayloadType::Keyword => {
+                    let card = src.cardinality.unwrap_or(100);
+                    let mult = src.length_multiplier.unwrap_or(1);
+                    let condition = if let Some(match_any) = fp.match_any {
+                        MatchValue::Keywords(RepeatedStrings {
+                            strings: (0..match_any)
+                                .map(|_| random_keyword(rng, card, mult))
+                                .collect(),
+                        })
+                    } else {
+                        MatchValue::Keyword(random_keyword(rng, card, mult))
+                    };
+                    filter.must.push(Condition::matches(&fp.name, condition));
+                }
+                PayloadType::Integer => {
+                    let min = src.min.unwrap_or(0.0) as i64;
+                    let max = src.max.unwrap_or(100.0) as i64;
+                    let max = max.max(min + 1);
+                    let rand_int = rng.random_range(min..max);
+                    filter.must.push(Condition::range(
+                        &fp.name,
+                        Range {
+                            gt: None,
+                            gte: Some(rand_int as f64),
+                            lt: None,
+                            lte: None,
+                        },
+                    ));
+                }
+                PayloadType::Float => {
+                    filter.must.push(Condition::range(
+                        &fp.name,
+                        Range {
+                            gt: None,
+                            gte: Some(0.0),
+                            lt: None,
+                            lte: None,
+                        },
+                    ));
+                }
+                PayloadType::Bool => {
+                    filter.must.push(Condition::matches(
+                        &fp.name,
+                        rng.random_bool(src.true_ratio.unwrap_or(0.5)),
+                    ));
+                }
+                PayloadType::Uuid => {
+                    filter.must.push(Condition::matches(
+                        &fp.name,
+                        uuid::Uuid::new_v4().to_string(),
+                    ));
+                }
+                PayloadType::Geo => {
+                    let (lat, lon) = match self.geo_clusters.get(i).and_then(|c| c.as_ref()) {
+                        Some(centers) => {
+                            let &(clat, clon) = centers.choose(rng).unwrap();
+                            (
+                                clat + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
+                                clon + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
+                            )
+                        }
+                        None => (
+                            GEO_CENTER_LAT + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
+                            GEO_CENTER_LON + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
+                        ),
+                    };
+                    let radius = rng.random_range(GEO_RADIUS_METERS_MIN..GEO_RADIUS_METERS_MAX);
+                    filter.must.push(Condition::geo_radius(
+                        &fp.name,
+                        GeoRadius {
+                            center: Some(GeoPoint { lat, lon }),
+                            radius: radius as f32,
+                        },
+                    ));
+                }
+                PayloadType::Text => {
+                    let min_len = src.min_length.unwrap_or(2);
+                    let max_len = src.max_length.unwrap_or(min_len).max(min_len);
+                    let len = if max_len > min_len {
+                        rng.random_range(min_len..=max_len)
+                    } else {
+                        min_len
+                    };
+                    let text = match self.text_zipf.get(i).and_then(|z| z.as_ref()) {
+                        Some(zipf) => random_text(rng, len, zipf),
+                        None => (0..len)
+                            .map(|_| {
+                                format!(
+                                    "word_{}",
+                                    rng.random_range(
+                                        0..src.vocab_size.unwrap_or(DEFAULT_VOCAB_SIZE)
+                                    )
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                    };
+                    filter.must.push(Condition::matches_text(&fp.name, text));
+                }
+                PayloadType::Datetime => {}
+            }
+        }
+
+        if filter.must.is_empty() {
+            None
+        } else {
+            Some(filter)
+        }
+    }
 }
 
 /// Generates search queries from a parsed YAML [`SearchConfig`].
@@ -128,18 +301,11 @@ impl ConfigSearchGenerator {
                 }
             };
 
-            let text_zipf = filters.iter().map(Self::maybe_text_zipf).collect();
-            let geo_clusters = filters
-                .iter()
-                .map(|f| Self::maybe_geo_clusters(f, &mut rng))
-                .collect();
-
             per_request.push(RequestState {
                 dense_reader,
                 query_dataset,
                 sparse_zipf,
-                text_zipf,
-                geo_clusters,
+                filters: FilterGenerator::new(filters, &mut rng),
             });
         }
 
@@ -171,29 +337,6 @@ impl ConfigSearchGenerator {
         })
     }
 
-    fn maybe_text_zipf(filter: &FilterPayloadConfig) -> Option<rand_distr::Zipf<f64>> {
-        (filter.kind == PayloadType::Text && filter.source.distribution == DistributionKind::Zipf)
-            .then(|| create_zipf(filter.source.vocab_size.unwrap_or(DEFAULT_VOCAB_SIZE)))
-    }
-
-    fn maybe_geo_clusters(
-        filter: &FilterPayloadConfig,
-        rng: &mut impl Rng,
-    ) -> Option<Vec<(f64, f64)>> {
-        (filter.kind == PayloadType::Geo && filter.source.kind == PayloadSourceKind::RandomClusters)
-            .then(|| {
-                let count = filter.source.clusters.unwrap_or(10);
-                (0..count)
-                    .map(|_| {
-                        (
-                            GEO_CENTER_LAT + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
-                            GEO_CENTER_LON + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
-                        )
-                    })
-                    .collect()
-            })
-    }
-
     /// Pick a random request template and materialize one query from it.
     #[allow(dead_code)]
     pub fn make_query(&self, req_id: usize, rng: &mut impl Rng) -> GeneratedQuery {
@@ -221,7 +364,7 @@ impl ConfigSearchGenerator {
                 size,
                 datatype,
                 source,
-                filters,
+                filters: _,
             } => {
                 let (vector, expected_ids) = if let Some(query_dataset) = &state.query_dataset {
                     Self::read_dense_query(query_dataset)
@@ -239,14 +382,14 @@ impl ConfigSearchGenerator {
                 GeneratedQuery {
                     dense: Some((vector, using.clone())),
                     sparse: None,
-                    filter: self.build_filter(rng, filters, state),
+                    filter: state.filters.build(rng),
                     expected_ids,
                 }
             }
             SearchRequestConfig::Sparse {
                 using,
                 source,
-                filters,
+                filters: _,
             } => {
                 let ((values, indices), expected_ids) =
                     if let Some(query_dataset) = &state.query_dataset {
@@ -260,7 +403,7 @@ impl ConfigSearchGenerator {
                 GeneratedQuery {
                     dense: None,
                     sparse: Some((values, indices, using.clone())),
-                    filter: self.build_filter(rng, filters, state),
+                    filter: state.filters.build(rng),
                     expected_ids,
                 }
             }
@@ -348,136 +491,6 @@ impl ConfigSearchGenerator {
                 let (indices, values): (Vec<_>, Vec<_>) = pairs.into_iter().unzip();
                 (values, SparseIndices { data: indices })
             }
-        }
-    }
-
-    fn build_filter(
-        &self,
-        rng: &mut impl Rng,
-        filters: &[FilterPayloadConfig],
-        state: &RequestState,
-    ) -> Option<Filter> {
-        if filters.is_empty() {
-            return None;
-        }
-
-        let mut filter = Filter {
-            should: vec![],
-            must: vec![],
-            must_not: vec![],
-            min_should: None,
-        };
-
-        for (i, fp) in filters.iter().enumerate() {
-            let src = &fp.source;
-            match fp.kind {
-                PayloadType::Keyword => {
-                    let card = src.cardinality.unwrap_or(100);
-                    let mult = src.length_multiplier.unwrap_or(1);
-                    let condition = if let Some(match_any) = fp.match_any {
-                        MatchValue::Keywords(RepeatedStrings {
-                            strings: (0..match_any)
-                                .map(|_| random_keyword(rng, card, mult))
-                                .collect(),
-                        })
-                    } else {
-                        MatchValue::Keyword(random_keyword(rng, card, mult))
-                    };
-                    filter.must.push(Condition::matches(&fp.name, condition));
-                }
-                PayloadType::Integer => {
-                    let min = src.min.unwrap_or(0.0) as i64;
-                    let max = src.max.unwrap_or(100.0) as i64;
-                    let max = max.max(min + 1);
-                    let rand_int = rng.random_range(min..max);
-                    filter.must.push(Condition::range(
-                        &fp.name,
-                        Range {
-                            gt: None,
-                            gte: Some(rand_int as f64),
-                            lt: None,
-                            lte: None,
-                        },
-                    ));
-                }
-                PayloadType::Float => {
-                    filter.must.push(Condition::range(
-                        &fp.name,
-                        Range {
-                            gt: None,
-                            gte: Some(0.0),
-                            lt: None,
-                            lte: None,
-                        },
-                    ));
-                }
-                PayloadType::Bool => {
-                    filter.must.push(Condition::matches(
-                        &fp.name,
-                        rng.random_bool(src.true_ratio.unwrap_or(0.5)),
-                    ));
-                }
-                PayloadType::Uuid => {
-                    filter.must.push(Condition::matches(
-                        &fp.name,
-                        uuid::Uuid::new_v4().to_string(),
-                    ));
-                }
-                PayloadType::Geo => {
-                    let (lat, lon) = match state.geo_clusters.get(i).and_then(|c| c.as_ref()) {
-                        Some(centers) => {
-                            let &(clat, clon) = centers.choose(rng).unwrap();
-                            (
-                                clat + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
-                                clon + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
-                            )
-                        }
-                        None => (
-                            GEO_CENTER_LAT + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
-                            GEO_CENTER_LON + rng.random_range(-GEO_SPREAD_DEG..GEO_SPREAD_DEG),
-                        ),
-                    };
-                    let radius = rng.random_range(GEO_RADIUS_METERS_MIN..GEO_RADIUS_METERS_MAX);
-                    filter.must.push(Condition::geo_radius(
-                        &fp.name,
-                        GeoRadius {
-                            center: Some(GeoPoint { lat, lon }),
-                            radius: radius as f32,
-                        },
-                    ));
-                }
-                PayloadType::Text => {
-                    let min_len = src.min_length.unwrap_or(2);
-                    let max_len = src.max_length.unwrap_or(min_len).max(min_len);
-                    let len = if max_len > min_len {
-                        rng.random_range(min_len..=max_len)
-                    } else {
-                        min_len
-                    };
-                    let text = match state.text_zipf.get(i).and_then(|z| z.as_ref()) {
-                        Some(zipf) => random_text(rng, len, zipf),
-                        None => (0..len)
-                            .map(|_| {
-                                format!(
-                                    "word_{}",
-                                    rng.random_range(
-                                        0..src.vocab_size.unwrap_or(DEFAULT_VOCAB_SIZE)
-                                    )
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                            .join(" "),
-                    };
-                    filter.must.push(Condition::matches_text(&fp.name, text));
-                }
-                PayloadType::Datetime => {}
-            }
-        }
-
-        if filter.must.is_empty() {
-            None
-        } else {
-            Some(filter)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,14 @@ async fn run_scroll(
 ) -> Result<()> {
     let config = config::scroll::load(&scroll_args.file)?;
 
+    // `--rps` fires on a timer with no concurrency cap, so requests would race
+    // over the walks and keep restarting them.
+    if config.mode == config::scroll::ScrollMode::Sequential && args.rps.is_some() {
+        anyhow::bail!(
+            "`mode: sequential` walks one cursor per `--parallel` worker; it cannot be combined with `--rps`"
+        );
+    }
+
     let mut args = args;
     args.collection_name = config.collection.name.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,22 @@ async fn run_wait_index(args: &Args, stopped: Arc<AtomicBool>) -> Result<IndexPh
     Ok(IndexPhase { wait_secs })
 }
 
+/// `bfb scroll --file config.yaml`: YAML-config-driven scroll.
+async fn run_scroll(
+    args: Args,
+    scroll_args: args::ScrollArgs,
+    stopped: Arc<AtomicBool>,
+) -> Result<()> {
+    let config = config::scroll::load(&scroll_args.file)?;
+
+    let mut args = args;
+    args.collection_name = config.collection.name.clone();
+
+    let mut results = BenchmarkResults::new(&args, Some(scroll_args.file.clone()));
+    results.results.scroll = Some(query::scroll_with_config(&args, &config, stopped).await?);
+    results.write_if_requested(&args)
+}
+
 /// `bfb search --file config.yaml`: YAML-config-driven search.
 async fn run_search(
     args: Args,
@@ -91,12 +107,12 @@ async fn run_upload(
 }
 
 async fn run_benchmark(args: Args, stopped: Arc<AtomicBool>) -> Result<()> {
-    if let Some(Command::Search(search_args)) = args.command.clone() {
-        return run_search(args, search_args, stopped).await;
-    }
-
-    if let Some(Command::Upload(upload_args)) = args.command.clone() {
-        return run_upload(args, upload_args, stopped).await;
+    match args.command.clone() {
+        Some(Command::Search(search_args)) => return run_search(args, search_args, stopped).await,
+        Some(Command::Upload(upload_args)) => return run_upload(args, upload_args, stopped).await,
+        Some(Command::Scroll(scroll_args)) => return run_scroll(args, scroll_args, stopped).await,
+        // `Schema` is handled before the runtime starts; `None` falls through.
+        Some(Command::Schema) | None => {}
     }
 
     if args.search_quality && args.search_exact {

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,6 +8,7 @@ use qdrant_client::qdrant::ScrollPointsBuilder;
 
 use crate::args::Args;
 use crate::client::create_clients;
+use crate::config::scroll::ScrollConfig;
 use crate::config::search::SearchConfig;
 use crate::generators::random::UUID_PAYLOAD_KEY;
 use crate::results::QueryPhase;
@@ -40,6 +41,17 @@ pub async fn scroll(args: &Args, stopped: Arc<AtomicBool>) -> Result<QueryPhase>
     let uuids = get_uuids(args, &clients[0]).await?;
 
     let scroller = ScrollProcessor::new(args.clone(), stopped.clone(), clients, uuids);
+    process(args, stopped, scroller).await
+}
+
+/// YAML-config-driven scroll (`bfb scroll --file config.yaml`).
+pub async fn scroll_with_config(
+    args: &Args,
+    config: &ScrollConfig,
+    stopped: Arc<AtomicBool>,
+) -> Result<QueryPhase> {
+    let clients = create_clients(args)?;
+    let scroller = ScrollProcessor::from_config(args.clone(), config, stopped.clone(), clients);
     process(args, stopped, scroller).await
 }
 

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -5,8 +5,12 @@ use indicatif::ProgressBar;
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::ScrollPointsBuilder;
 
+use rand::{Rng, RngExt};
+
 use crate::args::Args;
 use crate::client::retry_with_clients;
+use crate::config::scroll::ScrollConfig;
+use crate::generators::queries::FilterGenerator;
 use crate::generators::random::{DEFAULT_VOCAB_SIZE, create_zipf, random_filter};
 use crate::processor::{Processor, Timing};
 
@@ -17,6 +21,18 @@ struct ScrollStats {
     full_timings: Vec<Timing>,
 }
 
+/// Where a scroll request's filter comes from.
+enum Filters {
+    /// Legacy `bfb --scroll`: filters come from the payload flags.
+    Flags {
+        uuids: Vec<String>,
+        zipf: Option<rand_distr::Zipf<f64>>,
+    },
+    /// `bfb scroll --file`: one generator per `requests:` template, one picked
+    /// at random per request.
+    Config(Vec<FilterGenerator>),
+}
+
 pub struct ScrollProcessor {
     args: Args,
     stopped: Arc<AtomicBool>,
@@ -24,11 +40,11 @@ pub struct ScrollProcessor {
     pub start_timestamp_millis: f64,
     start_time: std::time::Instant,
     stats: Mutex<ScrollStats>,
-    pub uuids: Vec<String>,
-    zipf: Option<rand_distr::Zipf<f64>>,
+    filters: Filters,
 }
 
 impl ScrollProcessor {
+    /// Flag-driven: filters come from `--keywords`, `--geo-payloads`, ….
     pub fn new(
         args: Args,
         stopped: Arc<AtomicBool>,
@@ -39,6 +55,32 @@ impl ScrollProcessor {
             .text_payloads
             .then(|| create_zipf(args.text_payload_vocabulary.unwrap_or(DEFAULT_VOCAB_SIZE)));
 
+        Self::with_filters(args, stopped, clients, Filters::Flags { uuids, zipf })
+    }
+
+    /// Config-driven: filters come from the YAML `requests:` templates.
+    pub fn from_config(
+        args: Args,
+        config: &ScrollConfig,
+        stopped: Arc<AtomicBool>,
+        clients: Vec<Qdrant>,
+    ) -> Self {
+        let mut rng = rand::rng();
+        let generators = config
+            .requests
+            .iter()
+            .map(|request| FilterGenerator::new(&request.filters, &mut rng))
+            .collect();
+
+        Self::with_filters(args, stopped, clients, Filters::Config(generators))
+    }
+
+    fn with_filters(
+        args: Args,
+        stopped: Arc<AtomicBool>,
+        clients: Vec<Qdrant>,
+        filters: Filters,
+    ) -> Self {
         ScrollProcessor {
             args,
             stopped,
@@ -49,8 +91,35 @@ impl ScrollProcessor {
                 .as_millis() as f64,
             start_time: std::time::Instant::now(),
             stats: Mutex::new(ScrollStats::default()),
-            uuids,
-            zipf,
+            filters,
+        }
+    }
+
+    fn build_filter(
+        &self,
+        rng: &mut impl Rng,
+        args: &Args,
+    ) -> Option<qdrant_client::qdrant::Filter> {
+        match &self.filters {
+            Filters::Flags { uuids, zipf } => random_filter(
+                rng,
+                &self.args.keywords,
+                &self.args.float_payloads,
+                &self.args.int_payloads,
+                uuids,
+                self.args.match_any,
+                self.args.geo_payloads,
+                self.args.bool_payloads,
+                args.keywords_length_multiplier,
+                zipf.as_ref(),
+            ),
+            Filters::Config(generators) if !generators.is_empty() => {
+                generators[rng.random_range(0..generators.len())].build(rng)
+            }
+            // `ScrollConfig::validate` rejects an empty `requests:` list, so this
+            // is unreachable today; scroll unfiltered rather than panic if a
+            // future caller builds a processor without going through it.
+            Filters::Config(_) => None,
         }
     }
 
@@ -66,18 +135,7 @@ impl ScrollProcessor {
 
         let start = std::time::Instant::now();
         let mut rng = rand::rng();
-        let query_filter = random_filter(
-            &mut rng,
-            &self.args.keywords,
-            &self.args.float_payloads,
-            &self.args.int_payloads,
-            &self.uuids,
-            self.args.match_any,
-            self.args.geo_payloads,
-            self.args.bool_payloads,
-            args.keywords_length_multiplier,
-            self.zipf.as_ref(),
-        );
+        let query_filter = self.build_filter(&mut rng, args);
 
         let mut request_builder = ScrollPointsBuilder::new(self.args.collection_name.clone())
             .limit(self.args.search_limit as u32)

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -3,13 +3,13 @@ use std::sync::{Arc, Mutex};
 
 use indicatif::ProgressBar;
 use qdrant_client::Qdrant;
-use qdrant_client::qdrant::ScrollPointsBuilder;
+use qdrant_client::qdrant::{PointId, Query, QueryPointsBuilder, Sample, ScrollPointsBuilder};
 
 use rand::{Rng, RngExt};
 
 use crate::args::Args;
 use crate::client::retry_with_clients;
-use crate::config::scroll::ScrollConfig;
+use crate::config::scroll::{ScrollConfig, ScrollMode};
 use crate::generators::queries::FilterGenerator;
 use crate::generators::random::{DEFAULT_VOCAB_SIZE, create_zipf, random_filter};
 use crate::processor::{Processor, Timing};
@@ -33,6 +33,13 @@ enum Filters {
     Config(Vec<FilterGenerator>),
 }
 
+/// A `Sequential` walk in progress. The filter is held for the whole walk: a
+/// cursor only means anything against the query that produced it.
+struct Walk {
+    filter: Option<qdrant_client::qdrant::Filter>,
+    offset: PointId,
+}
+
 pub struct ScrollProcessor {
     args: Args,
     stopped: Arc<AtomicBool>,
@@ -41,6 +48,10 @@ pub struct ScrollProcessor {
     start_time: std::time::Instant,
     stats: Mutex<ScrollStats>,
     filters: Filters,
+    mode: ScrollMode,
+    /// `Sequential` only: one walk per in-flight slot, so each of the
+    /// `--parallel` workers walks its own stretch of the collection.
+    walks: Vec<Mutex<Option<Walk>>>,
 }
 
 impl ScrollProcessor {
@@ -55,7 +66,13 @@ impl ScrollProcessor {
             .text_payloads
             .then(|| create_zipf(args.text_payload_vocabulary.unwrap_or(DEFAULT_VOCAB_SIZE)));
 
-        Self::with_filters(args, stopped, clients, Filters::Flags { uuids, zipf })
+        Self::with_filters(
+            args,
+            stopped,
+            clients,
+            Filters::Flags { uuids, zipf },
+            ScrollMode::default(),
+        )
     }
 
     /// Config-driven: filters come from the YAML `requests:` templates.
@@ -72,7 +89,13 @@ impl ScrollProcessor {
             .map(|request| FilterGenerator::new(&request.filters, &mut rng))
             .collect();
 
-        Self::with_filters(args, stopped, clients, Filters::Config(generators))
+        Self::with_filters(
+            args,
+            stopped,
+            clients,
+            Filters::Config(generators),
+            config.mode,
+        )
     }
 
     fn with_filters(
@@ -80,7 +103,12 @@ impl ScrollProcessor {
         stopped: Arc<AtomicBool>,
         clients: Vec<Qdrant>,
         filters: Filters,
+        mode: ScrollMode,
     ) -> Self {
+        let walks = (0..args.parallel.max(1))
+            .map(|_| Mutex::new(None))
+            .collect();
+
         ScrollProcessor {
             args,
             stopped,
@@ -92,6 +120,8 @@ impl ScrollProcessor {
             start_time: std::time::Instant::now(),
             stats: Mutex::new(ScrollStats::default()),
             filters,
+            mode,
+            walks,
         }
     }
 
@@ -123,27 +153,24 @@ impl ScrollProcessor {
         }
     }
 
-    pub async fn scroll(
+    /// One scroll request. Returns `(points, server_secs, next_page_offset)`.
+    async fn scroll_cursor(
         &self,
-        _req_id: usize,
         args: &Args,
-        progress_bar: &ProgressBar,
-    ) -> Result<(), anyhow::Error> {
-        if self.stopped.load(std::sync::atomic::Ordering::Relaxed) {
-            return Ok(());
-        }
-
-        let start = std::time::Instant::now();
-        let mut rng = rand::rng();
-        let query_filter = self.build_filter(&mut rng, args);
-
+        filter: Option<qdrant_client::qdrant::Filter>,
+        offset: Option<PointId>,
+    ) -> Result<(usize, f64, Option<PointId>), anyhow::Error> {
         let mut request_builder = ScrollPointsBuilder::new(self.args.collection_name.clone())
             .limit(self.args.search_limit as u32)
             .with_payload(self.args.search_with_payload)
             .with_vectors(self.args.search_with_vectors);
 
-        if let Some(filter) = query_filter {
+        if let Some(filter) = filter {
             request_builder = request_builder.filter(filter);
+        }
+
+        if let Some(offset) = offset {
+            request_builder = request_builder.offset(offset);
         }
 
         if let Some(read_consistency) = self.args.read_consistency {
@@ -158,6 +185,76 @@ impl ScrollProcessor {
         let res = retry_with_clients(&self.clients, args, |client| client.scroll(request.clone()))
             .await?;
 
+        Ok((res.result.len(), res.time, res.next_page_offset))
+    }
+
+    /// A vector-less `query` with `sample: random` — a randomly-sampled page.
+    async fn sample(
+        &self,
+        args: &Args,
+        filter: Option<qdrant_client::qdrant::Filter>,
+    ) -> Result<(usize, f64), anyhow::Error> {
+        let mut request_builder = QueryPointsBuilder::new(self.args.collection_name.clone())
+            .query(Query::new_sample(Sample::Random))
+            .limit(self.args.search_limit as u64)
+            .with_payload(self.args.search_with_payload)
+            .with_vectors(self.args.search_with_vectors);
+
+        if let Some(filter) = filter {
+            request_builder = request_builder.filter(filter);
+        }
+
+        if let Some(read_consistency) = self.args.read_consistency {
+            request_builder = request_builder.read_consistency(read_consistency);
+        }
+
+        if let Some(timeout) = self.args.timeout {
+            request_builder = request_builder.timeout(timeout as u64);
+        }
+
+        let request = request_builder.build();
+        let res =
+            retry_with_clients(&self.clients, args, |client| client.query(request.clone())).await?;
+
+        Ok((res.result.len(), res.time))
+    }
+
+    pub async fn scroll(
+        &self,
+        req_id: usize,
+        args: &Args,
+        progress_bar: &ProgressBar,
+    ) -> Result<(), anyhow::Error> {
+        if self.stopped.load(std::sync::atomic::Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        let start = std::time::Instant::now();
+        let mut rng = rand::rng();
+        let filter = self.build_filter(&mut rng, args);
+
+        let (result_len, server_time) = match self.mode {
+            ScrollMode::Sample => self.sample(args, filter).await?,
+            ScrollMode::Scroll => {
+                let (len, time, _) = self.scroll_cursor(args, filter, None).await?;
+                (len, time)
+            }
+            ScrollMode::Sequential => {
+                let slot = req_id % self.walks.len();
+                // A walk in progress keeps its own filter; the fresh one is only
+                // used to start a new walk.
+                let (filter, offset) = match self.walks[slot].lock().unwrap().take() {
+                    Some(walk) => (walk.filter, Some(walk.offset)),
+                    None => (filter, None),
+                };
+
+                let (len, time, next) = self.scroll_cursor(args, filter.clone(), offset).await?;
+                // No next page: leave the slot empty so the walk restarts from the top.
+                *self.walks[slot].lock().unwrap() = next.map(|offset| Walk { filter, offset });
+                (len, time)
+            }
+        };
+
         let elapsed = start.elapsed().as_secs_f32();
         let delay_millis = self.start_time.elapsed().as_millis() as u32;
         let full_timing = Timing {
@@ -165,21 +262,20 @@ impl ScrollProcessor {
             value: elapsed,
         };
 
-        if res.time > self.args.timing_threshold {
-            progress_bar.println(format!("Slow scroll: {:?}", res.time));
+        if server_time > self.args.timing_threshold {
+            progress_bar.println(format!("Slow scroll: {server_time:?}"));
         }
 
-        if res.result.len() < self.args.search_limit {
+        if result_len < self.args.search_limit {
             progress_bar.println(format!(
-                "Scroll result is too small: {} of {}",
-                res.result.len(),
+                "Scroll result is too small: {result_len} of {}",
                 self.args.search_limit
             ));
         }
 
         let server_timing = Timing {
             delay_millis,
-            value: res.time as f32,
+            value: server_time as f32,
         };
 
         let rps_timing = Timing {


### PR DESCRIPTION
Scroll was only reachable as a `--scroll` flag as a part of a full benchmark run, so timing it meant re-uploading first. This makes it a subcommand that runs against a collection that already exists: `bfb scroll --file examples/scroll-config.yaml -n 50k -p 8 --json scroll.json`. Results land under `results.scroll`, same shape as `results.search`. The YAML describes the shape of scroll requests — the collection, and the payload filters to scroll by. One template is picked at random per request with fresh filter values, so a single run can compare filtered against unfiltered:

```
  collection:                                                                                                                                                                                                                                 
    name: benchmark

  mode: scroll|sequential|sample
                                                                                                                                                                                                                                              
  requests:                                                                                                                                                                                                                                   
    - filters: []          # unfiltered                                                                                                                                                                                                       
    - filters:                                                                                                                                                                                                                                
        - name: color                                                                                                                                                                                                                         
          type: keyword                                                                                                                                                                                                                       
          source: { type: random, cardinality: 100 }
```
Filter entries use the same payload type / source vocabulary as the upload and search configs, because it's now literally the same code, with no change in behavior.

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?