### PR TITLE
fix: scroll `sequential` walks were racing and re-reading page one

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ requests:
 | mode | request |
 | --- | --- |
 | `scroll` | first page matching the filter; every request starts at the top (default) |
-| `sequential` | cursor walk — each request resumes from the previous page, wrapping once exhausted. One walk per `-p` worker |
+| `sequential` | cursor walk — each request resumes from the previous page. Walks open at a random point, so concurrent ones cover different stretches instead of all re-reading the first page |
 | `sample` | a vector-less `query` with `sample: random` |
 
 Filter entries use the same payload `type` / `source` vocabulary as the upload

--- a/examples/scroll-config.yaml
+++ b/examples/scroll-config.yaml
@@ -17,7 +17,8 @@ collection:
 #   scroll      fetch the first page matching the filter; every request starts
 #               at the top (default)
 #   sequential  walk the collection — each request resumes from the previous
-#               page's cursor, wrapping once exhausted. One walk per `-p` worker
+#               page's cursor. Walks open at a random point, so concurrent ones
+#               cover different stretches rather than all re-reading page one
 #   sample      a vector-less `query` with `sample: random`
 mode: scroll
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,14 +41,6 @@ async fn run_scroll(
 ) -> Result<()> {
     let config = config::scroll::load(&scroll_args.file)?;
 
-    // `--rps` fires on a timer with no concurrency cap, so requests would race
-    // over the walks and keep restarting them.
-    if config.mode == config::scroll::ScrollMode::Sequential && args.rps.is_some() {
-        anyhow::bail!(
-            "`mode: sequential` walks one cursor per `--parallel` worker; it cannot be combined with `--rps`"
-        );
-    }
-
     let mut args = args;
     args.collection_name = config.collection.name.clone();
 

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -232,6 +232,10 @@ impl ScrollProcessor {
             request_builder = request_builder.filter(filter);
         }
 
+        if let Some(read_consistency) = self.args.read_consistency {
+            request_builder = request_builder.read_consistency(read_consistency);
+        }
+
         if let Some(timeout) = self.args.timeout {
             request_builder = request_builder.timeout(timeout as u64);
         }

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -49,9 +49,10 @@ pub struct ScrollProcessor {
     stats: Mutex<ScrollStats>,
     filters: Filters,
     mode: ScrollMode,
-    /// `Sequential` only: one walk per in-flight slot, so each of the
-    /// `--parallel` workers walks its own stretch of the collection.
-    walks: Vec<Mutex<Option<Walk>>>,
+    /// `Sequential` only: a pool of walks in progress. A request checks one out for
+    /// the duration of its scroll and returns it advanced, so a walk is never shared.
+    /// The pool sizes itself: with N requests in flight there are at most N walks.
+    walks: Mutex<Vec<Walk>>,
 }
 
 impl ScrollProcessor {
@@ -105,10 +106,6 @@ impl ScrollProcessor {
         filters: Filters,
         mode: ScrollMode,
     ) -> Self {
-        let walks = (0..args.parallel.max(1))
-            .map(|_| Mutex::new(None))
-            .collect();
-
         ScrollProcessor {
             args,
             stopped,
@@ -121,7 +118,7 @@ impl ScrollProcessor {
             stats: Mutex::new(ScrollStats::default()),
             filters,
             mode,
-            walks,
+            walks: Mutex::new(Vec::new()),
         }
     }
 
@@ -219,9 +216,56 @@ impl ScrollProcessor {
         Ok((res.result.len(), res.time))
     }
 
+    /// One random point matching the filter, used to seed a walk.
+    async fn random_point(
+        &self,
+        args: &Args,
+        filter: Option<qdrant_client::qdrant::Filter>,
+    ) -> Result<Option<PointId>, anyhow::Error> {
+        let mut request_builder = QueryPointsBuilder::new(self.args.collection_name.clone())
+            .query(Query::new_sample(Sample::Random))
+            .limit(1)
+            .with_payload(false)
+            .with_vectors(false);
+
+        if let Some(filter) = filter {
+            request_builder = request_builder.filter(filter);
+        }
+
+        if let Some(timeout) = self.args.timeout {
+            request_builder = request_builder.timeout(timeout as u64);
+        }
+
+        let request = request_builder.build();
+        let res =
+            retry_with_clients(&self.clients, args, |client| client.query(request.clone())).await?;
+
+        Ok(res.result.first().and_then(|point| point.id.clone()))
+    }
+
+    /// Check out a walk in progress, or open a new one at a random point. Walks start
+    /// at random offsets so that concurrent ones cover different stretches of the
+    /// collection: seeded from the top they would all re-read the same pages.
+    async fn acquire_walk(
+        &self,
+        args: &Args,
+        filter: Option<qdrant_client::qdrant::Filter>,
+    ) -> Result<(Option<qdrant_client::qdrant::Filter>, Option<PointId>), anyhow::Error> {
+        // Bind before the `if let` so the guard is dropped before the await below.
+        let resumed = self.walks.lock().unwrap().pop();
+        if let Some(walk) = resumed {
+            // A walk in progress keeps its own filter: the cursor only means
+            // anything against the query that produced it.
+            return Ok((walk.filter, Some(walk.offset)));
+        }
+
+        let offset = self.random_point(args, filter.clone()).await?;
+        Ok((filter, offset))
+    }
+
     pub async fn scroll(
         &self,
-        req_id: usize,
+        _req_id: usize,
         args: &Args,
         progress_bar: &ProgressBar,
     ) -> Result<(), anyhow::Error> {
@@ -229,9 +273,17 @@ impl ScrollProcessor {
             return Ok(());
         }
 
-        let start = std::time::Instant::now();
         let mut rng = rand::rng();
         let filter = self.build_filter(&mut rng, args);
+
+        // Opening a walk costs a seeding query. That is setup, so it is resolved
+        // before the timer starts rather than charged to the request.
+        let walk = match self.mode {
+            ScrollMode::Sequential => Some(self.acquire_walk(args, filter.clone()).await?),
+            _ => None,
+        };
+
+        let start = std::time::Instant::now();
 
         let (result_len, server_time) = match self.mode {
             ScrollMode::Sample => self.sample(args, filter).await?,
@@ -240,17 +292,14 @@ impl ScrollProcessor {
                 (len, time)
             }
             ScrollMode::Sequential => {
-                let slot = req_id % self.walks.len();
-                // A walk in progress keeps its own filter; the fresh one is only
-                // used to start a new walk.
-                let (filter, offset) = match self.walks[slot].lock().unwrap().take() {
-                    Some(walk) => (walk.filter, Some(walk.offset)),
-                    None => (filter, None),
-                };
+                let (filter, offset) = walk.expect("sequential acquires its walk above");
 
                 let (len, time, next) = self.scroll_cursor(args, filter.clone(), offset).await?;
-                // No next page: leave the slot empty so the walk restarts from the top.
-                *self.walks[slot].lock().unwrap() = next.map(|offset| Walk { filter, offset });
+                // Return the walk advanced. A walk that ran off the end is not returned:
+                // the next request opens a fresh one elsewhere instead of replaying it.
+                if let Some(offset) = next {
+                    self.walks.lock().unwrap().push(Walk { filter, offset });
+                }
                 (len, time)
             }
         };


### PR DESCRIPTION
* Every walk started at the top. A fresh walk was opened with offset: None, which means "from the beginning of the collection." So all concurrent walks began at point 0 and marched through the same pages in lockstep — the first fetched each page from disk, the rest got cache hits. Walks now open at a random point, so concurrent walks cover different stretches and each page is genuinely read once.
* Drops the --rps guard. It was added to block mode: sequential with --rps, purely because unbounded concurrency guaranteed the slot collision. The pool removes the race, so the restriction — and its now-false comment — is gone; --rps runs sequential correctly, with the walk count simply floating with the in-flight request count.

before:  
walk 0 ─┐
walk 1 ─┼─ all from point 0 ──▶   1 disk read, N−1 cache hits
walk N ─┘

after:   
walk 0 ──── from random point A ──▶
walk 1 ──── from random point B ──▶   each page read once, from disk
walk N ──── from random point C ──▶