### PR TITLE
fix: rename stale `payloads:` key in upload-config example, add hybrid example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iml
 
 # Local benchmark data & outputs
+/datasets/
 /tmp-data/
 /logs/
 *.fbin

--- a/examples/simple-hybrid.yaml
+++ b/examples/simple-hybrid.yaml
@@ -1,0 +1,47 @@
+# Example bfb upload config for a simple hybrid (dense + sparse) collection:
+# one 768-d dense vector with turbo-2bit quantization and one zipf-distributed
+# sparse vector, plus a couple of payload fields to filter on.
+#
+#   bfb upload --file examples/simple-hybrid.yaml -n 1M -b 256 -p 16 -t 8 \
+#       --uri http://localhost:6334
+
+collection:
+  name: benchmark
+  id: uuid
+  on_disk_payload: true
+
+  optimizers:
+    default_segment_number: 3
+
+  quantization:
+    type: turbo-2bit
+    always_ram: true
+
+  vectors:
+    - name: image
+      size: 768
+      distance: cosine
+      datatype: float32
+      on_disk: true
+      source: random
+
+  sparse_vectors:
+    - name: bm25
+      on_disk: true
+      source:
+        type: random
+        vocab_size: 100000
+        length: 100
+        distribution: zipf
+
+  fields:
+    - name: a
+      type: keyword
+      source:
+        type: random
+        cardinality: 10
+        values_per_point: 1
+    - name: b
+      type: float
+      source: { type: random, min: -1.0, max: 1.0 }
+

--- a/examples/upload-config.yaml
+++ b/examples/upload-config.yaml
@@ -51,7 +51,7 @@ collection:
         length: 1000
         distribution: zipf        # uniform | zipf
 
-  payloads:
+  fields:
     - name: color
       type: keyword
       source:


### PR DESCRIPTION
## What

- **Fix `examples/upload-config.yaml`**: it still used the `payloads:` key from before the `payloads` → `fields` rename (386995c), and since the config uses `deny_unknown_fields` the example failed to parse:
  ```
  collection: unknown field `payloads`, expected one of ..., `payload`, `fields` at line 54 column 3
  ```
- **Add `examples/simple-hybrid.yaml`**: a minimal hybrid (dense + sparse) upload config — one 768-d dense vector with collection-level turbo-2bit quantization, one zipf-distributed sparse vector, and two payload fields.
- **Ignore `/datasets/`** in `.gitignore` — the default dataset download cache (`BFB_DATASETS_DIR`) previously showed up as untracked noise after running any dataset example.

## Verification

All 7 files in `examples/` were run against their respective subcommands (`bfb upload/search/scroll --file …` pointed at a dead port, so config parsing and `validate()` run fully); every one now parses cleanly. `cargo test`: 96 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)