### PR TITLE
feat: use --shard-key in search, query, and scroll requests

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 use anyhow::Result;
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::ScrollPointsBuilder;
+use qdrant_client::qdrant::shard_key::Key;
 
 use crate::args::Args;
 use crate::client::create_clients;
@@ -71,6 +72,9 @@ async fn get_uuids(args: &Args, client: &Qdrant) -> Result<Vec<String>> {
     let mut scroll_builder = ScrollPointsBuilder::new(&args.collection_name)
         .with_payload(true)
         .limit(args.num_vectors_or_default() as u32);
+    if let Some(shard_key) = &args.shard_key {
+        scroll_builder = scroll_builder.shard_key_selector(vec![Key::Keyword(shard_key.clone())]);
+    }
     if let Some(timeout) = args.timeout {
         scroll_builder = scroll_builder.timeout(timeout as u64);
     }

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use indicatif::ProgressBar;
 use qdrant_client::Qdrant;
+use qdrant_client::qdrant::shard_key::Key;
 use qdrant_client::qdrant::{PointId, Query, QueryPointsBuilder, Sample, ScrollPointsBuilder};
 
 use rand::{Rng, RngExt};
@@ -174,6 +175,11 @@ impl ScrollProcessor {
             request_builder = request_builder.read_consistency(read_consistency);
         }
 
+        if let Some(shard_key) = &self.args.shard_key {
+            request_builder =
+                request_builder.shard_key_selector(vec![Key::Keyword(shard_key.clone())]);
+        }
+
         if let Some(timeout) = self.args.timeout {
             request_builder = request_builder.timeout(timeout as u64);
         }
@@ -205,6 +211,11 @@ impl ScrollProcessor {
             request_builder = request_builder.read_consistency(read_consistency);
         }
 
+        if let Some(shard_key) = &self.args.shard_key {
+            request_builder =
+                request_builder.shard_key_selector(vec![Key::Keyword(shard_key.clone())]);
+        }
+
         if let Some(timeout) = self.args.timeout {
             request_builder = request_builder.timeout(timeout as u64);
         }
@@ -234,6 +245,11 @@ impl ScrollProcessor {
 
         if let Some(read_consistency) = self.args.read_consistency {
             request_builder = request_builder.read_consistency(read_consistency);
+        }
+
+        if let Some(shard_key) = &self.args.shard_key {
+            request_builder =
+                request_builder.shard_key_selector(vec![Key::Keyword(shard_key.clone())]);
         }
 
         if let Some(timeout) = self.args.timeout {

--- a/src/search/from_args.rs
+++ b/src/search/from_args.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use indicatif::ProgressBar;
 use qdrant_client::Qdrant;
+use qdrant_client::qdrant::shard_key::Key;
 use qdrant_client::qdrant::{
     PrefetchQueryBuilder, QuantizationSearchParamsBuilder, Query, QueryBatchPointsBuilder,
     QueryPointsBuilder, SearchParamsBuilder, SparseIndices, VectorInput,
@@ -164,6 +165,11 @@ impl SearchProcessor {
 
         if let Some(read_consistency) = self.args.read_consistency {
             request_builder = request_builder.read_consistency(read_consistency);
+        }
+
+        if let Some(shard_key) = &self.args.shard_key {
+            request_builder =
+                request_builder.shard_key_selector(vec![Key::Keyword(shard_key.clone())]);
         }
 
         request_builder

--- a/src/search/from_config.rs
+++ b/src/search/from_config.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use indicatif::ProgressBar;
 use qdrant_client::Qdrant;
+use qdrant_client::qdrant::shard_key::Key;
 use qdrant_client::qdrant::{
     PrefetchQueryBuilder, QuantizationSearchParamsBuilder, Query, QueryBatchPointsBuilder,
     QueryPointsBuilder, SearchParamsBuilder, SparseIndices, VectorInput,
@@ -102,6 +103,11 @@ impl ConfigSearchProcessor {
 
         if let Some(read_consistency) = self.args.read_consistency {
             request_builder = request_builder.read_consistency(read_consistency);
+        }
+
+        if let Some(shard_key) = &self.args.shard_key {
+            request_builder =
+                request_builder.shard_key_selector(vec![Key::Keyword(shard_key.clone())]);
         }
 
         request_builder


### PR DESCRIPTION
## Summary

`--shard-key` was only applied to upserts and collection creation, so read requests always fanned out across **all** shards even when a shard key was provided. This applies the shard-key selector to every applicable request so reads target the same shard the data was written to.

## Changes

| File | Request | Change |
|------|---------|--------|
| `src/search/from_args.rs` | flag-driven search (`QueryPointsBuilder`) | selector added in `create_request_builder` — flows into every batched query, including the exact-search quality pass |
| `src/search/from_config.rs` | config-driven search | same, in its `create_request_builder` |
| `src/scroll.rs` | `scroll_cursor`, `sample`, `random_point` | selector added to all three |
| `src/query.rs` | `get_uuids` pre-fetch scroll | selector added so UUIDs are read from the correct shard |

All use the same idiom already established in `upsert.rs`:

```rust
if let Some(shard_key) = &args.shard_key {
    request_builder = request_builder.shard_key_selector(vec![Key::Keyword(shard_key.clone())]);
}
```

## Notes

- `QueryBatchPointsBuilder` has no top-level shard-key selector in qdrant-client 1.18 — the per-query selectors inside the batch are what route the request, which is where they're set.
- When `--shard-key` is not provided, behavior is unchanged (requests span all shards).
- `cargo build` passes. Not yet exercised end-to-end against a live sharded collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)