### PR TITLE
feat: track qdrant-client dev, expose 1.19 collection & search options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,28 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,12 +97,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "axum"
-version = "0.7.9"
+name = "aws-lc-rs"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
- "async-trait",
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
@@ -137,29 +137,26 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "sync_wrapper",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -237,6 +234,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -334,10 +333,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "console"
@@ -492,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +619,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -737,7 +767,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -754,12 +784,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -887,7 +911,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -920,7 +943,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1043,16 +1066,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1148,6 +1161,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,9 +1284,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -1419,6 +1491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1482,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1495,18 +1573,17 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "qdrant-client"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cef4e669bcf9c07471463adab5ee080dd9bc9381f3652ea4981f6030b2c309"
+version = "1.16.1-dev"
+source = "git+https://github.com/qdrant/rust-client?branch=dev#738227709dab2a6473f3d60cc845bf2313f9dfea"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -1519,9 +1596,10 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -1547,7 +1625,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1560,6 +1638,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -1584,7 +1663,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1612,22 +1691,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -1644,31 +1712,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1742,9 +1791,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -1764,14 +1813,12 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -1779,7 +1826,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1803,6 +1849,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1876,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1843,15 +1899,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,11 +1909,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1883,6 +1958,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1960,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1972,24 +2056,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2019,6 +2091,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,16 +2117,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -2214,7 +2292,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2266,11 +2344,10 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64",
@@ -2285,37 +2362,27 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
  "rustls-native-certs",
- "rustls-pemfile",
- "socket2 0.5.10",
+ "socket2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "tonic-prost"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.6",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -2326,11 +2393,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2346,7 +2417,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -2509,6 +2580,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,16 +2694,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2639,7 +2720,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -2661,6 +2742,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2687,6 +2777,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2884,7 +2983,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2915,7 +3014,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -2934,7 +3033,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ half = "2.7"
 hdf5-pure-rust = "0.3.10"
 indicatif = "0.18.4"
 memmap2 = "0.9.10"
-qdrant-client = "1.18.0"
+qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "dev" }
 rand = "0.10.1"
 rand_distr = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Options:
       --distance <DISTANCE>
           Distance function used for comparing vectors [default: Cosine]
       --datatype <DATATYPE>
-          Vector datatypes (Uint8, Float16, Float32)
+          Vector datatypes (Uint8, Float16, Float32, Turbo4)
       --mmap-threshold <MMAP_THRESHOLD>
           Store vectors on disk
       --indexing-threshold <INDEXING_THRESHOLD>
@@ -309,6 +309,16 @@ Options:
           On disk index [possible values: true, false]
       --on-disk-vectors <ON_DISK_VECTORS>
           On disk vectors [possible values: true, false]
+      --memory-payload <PLACEMENT>
+          Memory placement of the payload storage (supersedes --on-disk-payload) [possible values: cold, cached, pinned]
+      --memory-payload-index <PLACEMENT>
+          Memory placement of the payload field indices (supersedes --on-disk-payload-index) [possible values: cold, cached, pinned]
+      --memory-index <PLACEMENT>
+          Memory placement of the HNSW graph and sparse index (supersedes --on-disk-index) [possible values: cold, cached, pinned]
+      --memory-vectors <PLACEMENT>
+          Memory placement of the vector storage (supersedes --on-disk-vectors) [possible values: cold, cached, pinned]
+      --memory-quantization <PLACEMENT>
+          Memory placement of the quantized vectors (supersedes --quantization-in-ram) [possible values: cold, cached, pinned]
       --timing-threshold <TIMING_THRESHOLD>
           Log requests if the take longer than this [default: 0.1]
       --uuids
@@ -399,6 +409,8 @@ Options:
           Whether to set dense vectors as multivectors
       --sparse-dim <SPARSE_DIM>
           Max dimension for sparse vectors (overrides --dim)
+      --sparse-idf
+          Create sparse vectors with the IDF modifier (BM25-style scoring). Required by --search-idf-corpus
       --jsonl-updates <JSONL_UPDATES>
           Path to the jsonl file to save update timings TIP: Use `qdrant/mri` to visualize the timings
       --jsonl-searches <JSONL_SEARCHES>
@@ -417,6 +429,8 @@ Options:
           Bench for search quality / accurracy too
       --full-scan-threshold <FULL_SCAN_THRESHOLD>
           Set a custom full-scan threshold
+      --search-idf-corpus
+          Compute sparse-vector IDF statistics over the points matching the query filter instead of the whole collection. Requires a filter to be generated (e.g. `-k`), and sparse vectors created with the IDF modifier
   -h, --help
           Print help
   -V, --version

--- a/examples/search-config.yaml
+++ b/examples/search-config.yaml
@@ -29,6 +29,21 @@ requests:
       length: 1000
       distribution: zipf
 
+  # Same sparse search, but IDF statistics are computed over a sub-corpus
+  # (Qdrant 1.19+) instead of the whole collection — the multi-tenant case.
+  # Only meaningful for sparse vectors created with the IDF modifier.
+  - kind: sparse
+    using: bm25
+    source:
+      type: random
+      vocab_size: 100000
+      length: 1000
+      distribution: zipf
+    idf_corpus:
+      - name: color
+        type: keyword
+        source: { type: random, cardinality: 100 }
+
   # Dense search with a keyword filter on the `color` payload field.
   - kind: dense
     using: text-emb
@@ -40,6 +55,19 @@ requests:
         source:
           type: random
           cardinality: 100
+
+  # Prefix filter on `color`: matches every keyword starting with the first 9
+  # characters of a generated value, so a shorter prefix is less selective.
+  # Requires the field's keyword index to be created with `prefix: true`.
+  - kind: dense
+    using: image
+    size: 1024
+    source: random
+    filters:
+      - name: color
+        type: keyword
+        source: { type: random, cardinality: 100 }
+        match_prefix: 9
 
   # Filtered search using an integer range on `price`.
   - kind: dense

--- a/examples/upload-config.yaml
+++ b/examples/upload-config.yaml
@@ -11,10 +11,16 @@ collection:
   id: integer                 # integer | uuid
   on_disk_payload: false
 
+  # Where the payload storage lives in RAM (Qdrant 1.19+). Supersedes
+  # `on_disk_payload`, which is still sent for older servers.
+  payload:
+    memory: cached            # cold | cached
+
   hnsw:
     m: 16
     ef_construct: 100
     on_disk: true
+    memory: cold              # cold | cached | pinned; supersedes `on_disk`
 
   optimizers:
     default_segment_number: 2
@@ -25,12 +31,14 @@ collection:
                               # turbo-1bit|turbo-1.5bit|turbo-2bit|turbo-4bit|
                               # product-x4|x8|x16|x32|x64
     always_ram: true
+    memory: pinned            # supersedes `always_ram`
 
   vectors:
     - name: image
       size: 1024
       distance: cosine        # cosine | dot | euclid | manhattan
-      datatype: float32       # float32 | float16 | uint8
+      datatype: float32       # float32 | float16 | uint8 | turbo4
+      memory: cached          # cold | cached (dense storage cannot be pinned)
       source: random
     - name: text-emb
       size: 384
@@ -45,6 +53,8 @@ collection:
 
   sparse_vectors:
     - name: bm25
+      memory: pinned              # keep the inverted index resident in RAM
+      modifier: idf               # none | idf; required by search `idf_corpus`
       source:
         type: random
         vocab_size: 100000
@@ -54,6 +64,10 @@ collection:
   fields:
     - name: color
       type: keyword
+      # Build the keyword index with prefix matching, so searches may use
+      # `match_prefix` filters on this field.
+      prefix: true
+      memory: cached
       source:
         type: random
         cardinality: 100

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -7,6 +7,8 @@ pub use consistency::{ReadConsistency, WriteOrdering};
 use clap::{ArgAction, Parser, Subcommand};
 use qdrant_client::qdrant;
 
+use crate::config::{MemoryKind, QuantKind};
+
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
 pub enum QuantizationArg {
     #[default]
@@ -24,6 +26,49 @@ pub enum QuantizationArg {
     ProductX16,
     ProductX32,
     ProductX64,
+}
+
+impl From<QuantizationArg> for QuantKind {
+    fn from(arg: QuantizationArg) -> Self {
+        match arg {
+            QuantizationArg::None => QuantKind::None,
+            QuantizationArg::Binary => QuantKind::Binary,
+            QuantizationArg::Binary2bit => QuantKind::Binary2bit,
+            QuantizationArg::Binary1p5bit => QuantKind::Binary15bit,
+            QuantizationArg::Turbo1bit => QuantKind::Turbo1bit,
+            QuantizationArg::Turbo1p5bit => QuantKind::Turbo15bit,
+            QuantizationArg::Turbo2bit => QuantKind::Turbo2bit,
+            QuantizationArg::Turbo4bit => QuantKind::Turbo4bit,
+            QuantizationArg::Scalar => QuantKind::Scalar,
+            QuantizationArg::ProductX4 => QuantKind::ProductX4,
+            QuantizationArg::ProductX8 => QuantKind::ProductX8,
+            QuantizationArg::ProductX16 => QuantKind::ProductX16,
+            QuantizationArg::ProductX32 => QuantKind::ProductX32,
+            QuantizationArg::ProductX64 => QuantKind::ProductX64,
+        }
+    }
+}
+
+/// Memory placement of a component's data (Qdrant 1.19+). Data is always
+/// persisted on disk; this only controls how it is held in RAM.
+#[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
+pub enum MemoryArg {
+    /// Not pre-loaded from disk; cached with usage.
+    Cold,
+    /// Pre-loaded into disk-cache RAM on start, may be evicted under pressure.
+    Cached,
+    /// Loaded in RAM and never evicted. Unsupported for dense vectors and payload storage.
+    Pinned,
+}
+
+impl From<MemoryArg> for MemoryKind {
+    fn from(arg: MemoryArg) -> Self {
+        match arg {
+            MemoryArg::Cold => MemoryKind::Cold,
+            MemoryArg::Cached => MemoryKind::Cached,
+            MemoryArg::Pinned => MemoryKind::Pinned,
+        }
+    }
 }
 
 /// Big F*cking Benchmark tool for stress-testing Qdrant
@@ -154,7 +199,7 @@ pub struct Args {
     #[clap(long, default_value = "Cosine")]
     pub distance: String,
 
-    /// Vector datatypes (Uint8, Float16, Float32)
+    /// Vector datatypes (Uint8, Float16, Float32, Turbo4)
     #[clap(long)]
     pub datatype: Option<String>,
 
@@ -189,6 +234,26 @@ pub struct Args {
     /// On disk vectors
     #[clap(long)]
     pub on_disk_vectors: Option<bool>,
+
+    /// Memory placement of the payload storage (supersedes --on-disk-payload)
+    #[clap(long, value_name = "PLACEMENT")]
+    pub memory_payload: Option<MemoryArg>,
+
+    /// Memory placement of the payload field indices (supersedes --on-disk-payload-index)
+    #[clap(long, value_name = "PLACEMENT")]
+    pub memory_payload_index: Option<MemoryArg>,
+
+    /// Memory placement of the HNSW graph and sparse index (supersedes --on-disk-index)
+    #[clap(long, value_name = "PLACEMENT")]
+    pub memory_index: Option<MemoryArg>,
+
+    /// Memory placement of the vector storage (supersedes --on-disk-vectors)
+    #[clap(long, value_name = "PLACEMENT")]
+    pub memory_vectors: Option<MemoryArg>,
+
+    /// Memory placement of the quantized vectors (supersedes --quantization-in-ram)
+    #[clap(long, value_name = "PLACEMENT")]
+    pub memory_quantization: Option<MemoryArg>,
 
     /// Log requests if the take longer than this
     #[clap(long, default_value_t = 0.1, global = true)]
@@ -378,6 +443,11 @@ pub struct Args {
     #[clap(long, value_parser = parse_number)]
     pub sparse_dim: Option<usize>,
 
+    /// Create sparse vectors with the IDF modifier (BM25-style scoring).
+    /// Required by --search-idf-corpus.
+    #[clap(long, default_value_t = false)]
+    pub sparse_idf: bool,
+
     /// Path to the jsonl file to save update timings
     /// TIP: Use `qdrant/mri` to visualize the timings
     #[clap(long, global = true)]
@@ -417,6 +487,12 @@ pub struct Args {
     /// Set a custom full-scan threshold.
     #[clap(long)]
     pub full_scan_threshold: Option<usize>,
+
+    /// Compute sparse-vector IDF statistics over the points matching the query
+    /// filter instead of the whole collection. Requires a filter to be generated
+    /// (e.g. `-k`), and sparse vectors created with the IDF modifier.
+    #[clap(long, default_value_t = false, global = true)]
+    pub search_idf_corpus: bool,
 }
 
 /// Subcommands. Absent ⇒ legacy flag-driven benchmark.

--- a/src/collection/from_args.rs
+++ b/src/collection/from_args.rs
@@ -9,20 +9,19 @@ use anyhow::Result;
 use qdrant_client::qdrant::shard_key::Key;
 use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
-    BinaryQuantizationBuilder, BinaryQuantizationEncoding, BoolIndexParamsBuilder,
-    CompressionRatio, CreateCollectionBuilder, CreateFieldIndexCollectionBuilder,
+    BoolIndexParamsBuilder, CreateCollectionBuilder, CreateFieldIndexCollectionBuilder,
     CreateShardKeyBuilder, CreateShardKeyRequestBuilder, Datatype, DatetimeIndexParamsBuilder,
     Distance, FieldType, FloatIndexParamsBuilder, GeoIndexParamsBuilder, HnswConfigDiffBuilder,
-    IntegerIndexParamsBuilder, KeywordIndexParamsBuilder, MultiVectorComparator,
-    MultiVectorConfigBuilder, OptimizersConfigDiffBuilder, ProductQuantizationBuilder,
-    QuantizationType, ScalarQuantizationBuilder, ShardingMethod, SparseIndexConfigBuilder,
-    SparseVectorConfig, SparseVectorParamsBuilder, TextIndexParamsBuilder, TokenizerType,
-    TurboQuantBitSize, TurboQuantizationBuilder, UuidIndexParamsBuilder, VectorParams,
+    IntegerIndexParamsBuilder, KeywordIndexParamsBuilder, Modifier, MultiVectorComparator,
+    MultiVectorConfigBuilder, OptimizersConfigDiffBuilder, PayloadStorageParamsBuilder,
+    ShardingMethod, SparseIndexConfigBuilder, SparseVectorConfig, SparseVectorParamsBuilder,
+    TextIndexParamsBuilder, TokenizerType, UuidIndexParamsBuilder, VectorParamsBuilder,
     VectorParamsMap, VectorsConfig,
 };
 use tokio::time::sleep;
 
-use crate::args::{Args, QuantizationArg};
+use super::from_config::{build_quantization_config, memory_to_i32};
+use crate::args::Args;
 use crate::client::random_client;
 use crate::generators::random::{
     BOOL_PAYLOAD_KEY, FLOAT_PAYLOAD_KEY, GEO_PAYLOAD_KEY, INTEGERS_PAYLOAD_KEY,
@@ -56,13 +55,14 @@ pub async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Resul
         return Ok(());
     }
 
-    let datatype = args
+    let datatype: Option<i32> = args
         .datatype
         .as_ref()
         .map(|datatype| match datatype.as_str() {
             "Uint8" => Datatype::Uint8.into(),
             "Float16" => Datatype::Float16.into(),
             "Float32" => Datatype::Float32.into(),
+            "Turbo4" => Datatype::Turbo4.into(),
             _ => {
                 panic!("Unknown vector datatype {datatype}")
             }
@@ -72,22 +72,30 @@ pub async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Resul
         MultiVectorConfigBuilder::new(MultiVectorComparator::MaxSim).build()
     });
 
-    let vector_param = VectorParams {
-        size: args.dim as u64,
-        distance: match args.distance.as_str() {
-            "Cosine" => Distance::Cosine.into(),
-            "Dot" => Distance::Dot.into(),
-            "Euclid" => Distance::Euclid.into(),
-            "Manhattan" => Distance::Manhattan.into(),
-            _ => {
-                panic!("Unknown distance {}", args.distance)
-            }
-        },
-        on_disk: args.on_disk_vectors,
-        multivector_config,
-        datatype,
-        ..Default::default()
+    let distance = match args.distance.as_str() {
+        "Cosine" => Distance::Cosine,
+        "Dot" => Distance::Dot,
+        "Euclid" => Distance::Euclid,
+        "Manhattan" => Distance::Manhattan,
+        _ => {
+            panic!("Unknown distance {}", args.distance)
+        }
     };
+
+    let mut vector_param_builder = VectorParamsBuilder::new(args.dim as u64, distance);
+    if let Some(on_disk) = args.on_disk_vectors {
+        vector_param_builder = vector_param_builder.on_disk(on_disk);
+    }
+    if let Some(memory) = args.memory_vectors {
+        vector_param_builder = vector_param_builder.memory(memory_to_i32(memory.into()));
+    }
+    if let Some(multivector_config) = multivector_config {
+        vector_param_builder = vector_param_builder.multivector_config(multivector_config);
+    }
+    if let Some(datatype) = datatype {
+        vector_param_builder = vector_param_builder.datatype(datatype);
+    }
+    let vector_param = vector_param_builder.build();
 
     let dense_vector_params = if args.vectors_per_point == 1 {
         Config::Params(vector_param)
@@ -110,11 +118,15 @@ pub async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Resul
                 if let Some(datatype) = datatype {
                     index_builder = index_builder.datatype(datatype);
                 }
-                let config = SparseVectorParamsBuilder::default()
-                    .index(index_builder)
-                    .build();
+                if let Some(memory) = args.memory_index {
+                    index_builder = index_builder.memory(memory_to_i32(memory.into()));
+                }
+                let mut config = SparseVectorParamsBuilder::default().index(index_builder);
+                if args.sparse_idf {
+                    config = config.modifier(Modifier::Idf);
+                }
 
-                (key, config)
+                (key, config.build())
             })
             .collect();
 
@@ -140,6 +152,9 @@ pub async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Resul
     }
     if args.hnsw_inline_storage {
         hnsw_config = hnsw_config.inline_storage(true);
+    }
+    if let Some(memory) = args.memory_index {
+        hnsw_config = hnsw_config.memory(memory_to_i32(memory.into()));
     }
 
     let mut optimizers_config = OptimizersConfigDiffBuilder::default();
@@ -171,6 +186,11 @@ pub async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Resul
         create_collection_builder = create_collection_builder.shard_number(shard_number as u32);
     }
 
+    if let Some(memory) = args.memory_payload {
+        create_collection_builder = create_collection_builder
+            .payload(PayloadStorageParamsBuilder::default().memory(memory_to_i32(memory.into())));
+    }
+
     if let Some(sparse_vector_config) = sparse_vectors_config {
         create_collection_builder =
             create_collection_builder.sparse_vectors_config(sparse_vector_config);
@@ -181,71 +201,15 @@ pub async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Resul
             create_collection_builder.sharding_method(ShardingMethod::Custom.into());
     }
 
-    if let Some(quantization) = args.quantization {
-        create_collection_builder = match quantization {
-            QuantizationArg::Scalar => create_collection_builder.quantization_config(
-                ScalarQuantizationBuilder::default()
-                    .r#type(QuantizationType::Int8.into())
-                    .quantile(0.99)
-                    .always_ram(args.quantization_in_ram.unwrap_or_default()),
-            ),
-            QuantizationArg::None => create_collection_builder,
-            QuantizationArg::Binary => create_collection_builder.quantization_config(
-                BinaryQuantizationBuilder::new(args.quantization_in_ram.unwrap_or_default()),
-            ),
-            QuantizationArg::Binary2bit => create_collection_builder.quantization_config(
-                BinaryQuantizationBuilder::new(args.quantization_in_ram.unwrap_or_default())
-                    .encoding(BinaryQuantizationEncoding::TwoBits),
-            ),
-            QuantizationArg::Binary1p5bit => create_collection_builder.quantization_config(
-                BinaryQuantizationBuilder::new(args.quantization_in_ram.unwrap_or_default())
-                    .encoding(BinaryQuantizationEncoding::OneAndHalfBits),
-            ),
-            QuantizationArg::Turbo1bit => create_collection_builder.quantization_config(
-                TurboQuantizationBuilder::new()
-                    .bits(TurboQuantBitSize::Bits1)
-                    .always_ram(args.quantization_in_ram.unwrap_or_default()),
-            ),
-            QuantizationArg::Turbo1p5bit => create_collection_builder.quantization_config(
-                TurboQuantizationBuilder::new()
-                    .bits(TurboQuantBitSize::Bits15)
-                    .always_ram(args.quantization_in_ram.unwrap_or_default()),
-            ),
-            QuantizationArg::Turbo2bit => create_collection_builder.quantization_config(
-                TurboQuantizationBuilder::new()
-                    .bits(TurboQuantBitSize::Bits2)
-                    .always_ram(args.quantization_in_ram.unwrap_or_default()),
-            ),
-            QuantizationArg::Turbo4bit => create_collection_builder.quantization_config(
-                TurboQuantizationBuilder::new()
-                    .bits(TurboQuantBitSize::Bits4)
-                    .always_ram(args.quantization_in_ram.unwrap_or_default()),
-            ),
-            quantization => {
-                let compression = match quantization {
-                    QuantizationArg::ProductX4 => CompressionRatio::X4,
-                    QuantizationArg::ProductX8 => CompressionRatio::X8,
-                    QuantizationArg::ProductX16 => CompressionRatio::X16,
-                    QuantizationArg::ProductX32 => CompressionRatio::X32,
-                    QuantizationArg::ProductX64 => CompressionRatio::X64,
-                    QuantizationArg::Scalar
-                    | QuantizationArg::Binary
-                    | QuantizationArg::Binary2bit
-                    | QuantizationArg::Binary1p5bit
-                    | QuantizationArg::Turbo1bit
-                    | QuantizationArg::Turbo1p5bit
-                    | QuantizationArg::Turbo2bit
-                    | QuantizationArg::Turbo4bit
-                    | QuantizationArg::None => {
-                        unreachable!()
-                    }
-                };
-                create_collection_builder.quantization_config(
-                    ProductQuantizationBuilder::new(compression.into())
-                        .always_ram(args.quantization_in_ram.unwrap_or_default()),
-                )
-            }
-        };
+    if let Some(quantization) = args.quantization
+        && let Some(quantization_config) = build_quantization_config(
+            quantization.into(),
+            args.quantization_in_ram.unwrap_or_default(),
+            args.memory_quantization.map(Into::into),
+        )
+    {
+        create_collection_builder =
+            create_collection_builder.quantization_config(quantization_config);
     }
 
     client.create_collection(create_collection_builder).await?;
@@ -280,7 +244,17 @@ pub async fn recreate_collection(args: &Args, stopped: Arc<AtomicBool>) -> Resul
 }
 
 async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Result<()> {
+    // `memory` supersedes `on_disk` on servers that understand it; both are sent
+    // so the same flags keep working against older ones.
+    let memory = args.memory_payload_index.map(|m| memory_to_i32(m.into()));
+
     for (idx, _) in args.keywords.iter().enumerate() {
+        let mut params = KeywordIndexParamsBuilder::default()
+            .on_disk(args.on_disk_payload_index)
+            .is_tenant(args.tenants.unwrap_or_default());
+        if let Some(memory) = memory {
+            params = params.memory(memory);
+        }
         client
             .create_field_index(
                 CreateFieldIndexCollectionBuilder::new(
@@ -288,11 +262,7 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
                     format!("{}{}", payload_prefixes(idx), KEYWORD_PAYLOAD_KEY),
                     FieldType::Keyword,
                 )
-                .field_index_params(
-                    KeywordIndexParamsBuilder::default()
-                        .on_disk(args.on_disk_payload_index)
-                        .is_tenant(args.tenants.unwrap_or_default()),
-                )
+                .field_index_params(params)
                 .wait(true),
             )
             .await
@@ -300,6 +270,12 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
     }
 
     for (idx, _) in args.float_payloads.iter().enumerate() {
+        let mut params = FloatIndexParamsBuilder::default()
+            .on_disk(args.on_disk_payload_index)
+            .is_principal(args.tenants.unwrap_or_default());
+        if let Some(memory) = memory {
+            params = params.memory(memory);
+        }
         client
             .create_field_index(
                 CreateFieldIndexCollectionBuilder::new(
@@ -307,11 +283,7 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
                     format!("{}{}", payload_prefixes(idx), FLOAT_PAYLOAD_KEY),
                     FieldType::Float,
                 )
-                .field_index_params(
-                    FloatIndexParamsBuilder::default()
-                        .on_disk(args.on_disk_payload_index)
-                        .is_principal(args.tenants.unwrap_or_default()),
-                )
+                .field_index_params(params)
                 .wait(true),
             )
             .await
@@ -319,6 +291,12 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
     }
 
     for (idx, _) in args.int_payloads.iter().enumerate() {
+        let mut params = IntegerIndexParamsBuilder::new(true, args.int_payloads_range)
+            .on_disk(args.on_disk_payload_index)
+            .is_principal(args.tenants.unwrap_or_default());
+        if let Some(memory) = memory {
+            params = params.memory(memory);
+        }
         client
             .create_field_index(
                 CreateFieldIndexCollectionBuilder::new(
@@ -326,11 +304,7 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
                     format!("{}{}", payload_prefixes(idx), INTEGERS_PAYLOAD_KEY),
                     FieldType::Integer,
                 )
-                .field_index_params(
-                    IntegerIndexParamsBuilder::new(true, args.int_payloads_range)
-                        .on_disk(args.on_disk_payload_index)
-                        .is_principal(args.tenants.unwrap_or_default()),
-                )
+                .field_index_params(params)
                 .wait(true),
             )
             .await
@@ -338,6 +312,12 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
     }
 
     if args.timestamp_payload {
+        let mut params = DatetimeIndexParamsBuilder::default()
+            .on_disk(args.on_disk_payload_index)
+            .is_principal(args.tenants.unwrap_or_default());
+        if let Some(memory) = memory {
+            params = params.memory(memory);
+        }
         client
             .create_field_index(
                 CreateFieldIndexCollectionBuilder::new(
@@ -345,11 +325,7 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
                     "timestamp",
                     FieldType::Datetime,
                 )
-                .field_index_params(
-                    DatetimeIndexParamsBuilder::default()
-                        .on_disk(args.on_disk_payload_index)
-                        .is_principal(args.tenants.unwrap_or_default()),
-                )
+                .field_index_params(params)
                 .wait(true),
             )
             .await
@@ -357,6 +333,12 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
     }
 
     if args.uuid_payloads {
+        let mut params = UuidIndexParamsBuilder::default()
+            .is_tenant(args.tenants.unwrap_or_default())
+            .on_disk(args.on_disk_payload_index);
+        if let Some(memory) = memory {
+            params = params.memory(memory);
+        }
         client
             .create_field_index(
                 CreateFieldIndexCollectionBuilder::new(
@@ -364,11 +346,7 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
                     UUID_PAYLOAD_KEY,
                     FieldType::Uuid,
                 )
-                .field_index_params(
-                    UuidIndexParamsBuilder::default()
-                        .is_tenant(args.tenants.unwrap_or_default())
-                        .on_disk(args.on_disk_payload_index),
-                )
+                .field_index_params(params)
                 .wait(true),
             )
             .await
@@ -376,6 +354,10 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
     }
 
     if args.geo_payloads {
+        let mut params = GeoIndexParamsBuilder::new().on_disk(args.on_disk_payload_index);
+        if let Some(memory) = memory {
+            params = params.memory(memory);
+        }
         client
             .create_field_index(
                 CreateFieldIndexCollectionBuilder::new(
@@ -383,9 +365,7 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
                     GEO_PAYLOAD_KEY,
                     FieldType::Geo,
                 )
-                .field_index_params(
-                    GeoIndexParamsBuilder::new().on_disk(args.on_disk_payload_index),
-                )
+                .field_index_params(params)
                 .wait(true),
             )
             .await
@@ -393,6 +373,10 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
     }
 
     if args.bool_payloads {
+        let mut params = BoolIndexParamsBuilder::default().on_disk(args.on_disk_payload_index);
+        if let Some(memory) = memory {
+            params = params.memory(memory);
+        }
         client
             .create_field_index(
                 CreateFieldIndexCollectionBuilder::new(
@@ -400,9 +384,7 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
                     BOOL_PAYLOAD_KEY,
                     FieldType::Bool,
                 )
-                .field_index_params(
-                    BoolIndexParamsBuilder::default().on_disk(args.on_disk_payload_index),
-                )
+                .field_index_params(params)
                 .wait(true),
             )
             .await
@@ -410,6 +392,11 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
     }
 
     if args.text_payloads {
+        let mut params =
+            TextIndexParamsBuilder::new(TokenizerType::Word).on_disk(args.on_disk_payload_index);
+        if let Some(memory) = memory {
+            params = params.memory(memory);
+        }
         client
             .create_field_index(
                 CreateFieldIndexCollectionBuilder::new(
@@ -417,10 +404,7 @@ async fn create_field_indices(args: &Args, client: &qdrant_client::Qdrant) -> Re
                     TEXT_PAYLOAD_KEY,
                     FieldType::Text,
                 )
-                .field_index_params(
-                    TextIndexParamsBuilder::new(TokenizerType::Word)
-                        .on_disk(args.on_disk_payload_index),
-                )
+                .field_index_params(params)
                 .wait(true),
             )
             .await

--- a/src/collection/from_config.rs
+++ b/src/collection/from_config.rs
@@ -13,28 +13,29 @@ use qdrant_client::qdrant::{
     CompressionRatio, CreateCollectionBuilder, CreateFieldIndexCollectionBuilder,
     CreateShardKeyBuilder, CreateShardKeyRequestBuilder, Datatype, DatetimeIndexParamsBuilder,
     Distance, FieldType, FloatIndexParamsBuilder, GeoIndexParamsBuilder, HnswConfigDiffBuilder,
-    IntegerIndexParamsBuilder, KeywordIndexParamsBuilder, MultiVectorComparator,
-    MultiVectorConfigBuilder, OptimizersConfigDiffBuilder, ProductQuantizationBuilder,
-    QuantizationType, ScalarQuantizationBuilder, ShardingMethod, SparseIndexConfigBuilder,
-    SparseVectorConfig, SparseVectorParamsBuilder, TextIndexParamsBuilder, TokenizerType,
-    TurboQuantBitSize, TurboQuantizationBuilder, UuidIndexParamsBuilder, VectorParams,
-    VectorParamsMap, VectorsConfig, quantization_config,
+    IntegerIndexParamsBuilder, KeywordIndexParamsBuilder, Memory, Modifier, MultiVectorComparator,
+    MultiVectorConfigBuilder, OptimizersConfigDiffBuilder, PayloadStorageParamsBuilder,
+    ProductQuantizationBuilder, QuantizationType, ScalarQuantizationBuilder, ShardingMethod,
+    SparseIndexConfigBuilder, SparseVectorConfig, SparseVectorParamsBuilder,
+    TextIndexParamsBuilder, TokenizerType, TurboQuantBitSize, TurboQuantizationBuilder,
+    UuidIndexParamsBuilder, VectorParams, VectorParamsBuilder, VectorParamsMap, VectorsConfig,
+    quantization_config,
 };
 use tokio::time::sleep;
 
 use crate::args::Args;
 use crate::client::random_client;
 use crate::config::{
-    ComparatorKind, DatatypeKind, DistanceKind, PayloadType, QuantKind, TokenizerKind,
-    UploadConfig, VectorConfig,
+    ComparatorKind, DatatypeKind, DistanceKind, MemoryKind, ModifierKind, PayloadType, QuantKind,
+    TokenizerKind, UploadConfig, VectorConfig,
 };
 
-fn distance_to_i32(distance: DistanceKind) -> i32 {
+fn distance_to_grpc(distance: DistanceKind) -> Distance {
     match distance {
-        DistanceKind::Cosine => Distance::Cosine.into(),
-        DistanceKind::Dot => Distance::Dot.into(),
-        DistanceKind::Euclid => Distance::Euclid.into(),
-        DistanceKind::Manhattan => Distance::Manhattan.into(),
+        DistanceKind::Cosine => Distance::Cosine,
+        DistanceKind::Dot => Distance::Dot,
+        DistanceKind::Euclid => Distance::Euclid,
+        DistanceKind::Manhattan => Distance::Manhattan,
     }
 }
 
@@ -43,81 +44,126 @@ fn datatype_to_i32(datatype: DatatypeKind) -> i32 {
         DatatypeKind::Float32 => Datatype::Float32.into(),
         DatatypeKind::Float16 => Datatype::Float16.into(),
         DatatypeKind::Uint8 => Datatype::Uint8.into(),
+        DatatypeKind::Turbo4 => Datatype::Turbo4.into(),
     }
 }
 
-fn build_quantization_config(
+/// Sparse value modifier (`modifier:`). `None` ⇒ leave it unset on the request.
+fn modifier_to_grpc(modifier: ModifierKind) -> Option<Modifier> {
+    match modifier {
+        ModifierKind::None => None,
+        ModifierKind::Idf => Some(Modifier::Idf),
+    }
+}
+
+/// Memory placement (`memory:`), as the gRPC enum value.
+pub fn memory_to_i32(memory: MemoryKind) -> i32 {
+    match memory {
+        MemoryKind::Cold => Memory::Cold.into(),
+        MemoryKind::Cached => Memory::Cached.into(),
+        MemoryKind::Pinned => Memory::Pinned.into(),
+    }
+}
+
+pub fn build_quantization_config(
     kind: QuantKind,
     always_ram: bool,
+    memory: Option<MemoryKind>,
 ) -> Option<quantization_config::Quantization> {
+    // `memory` supersedes `always_ram`; both are sent so older servers still
+    // honour the boolean.
     let config: quantization_config::Quantization = match kind {
         QuantKind::None => return None,
-        QuantKind::Scalar => ScalarQuantizationBuilder::default()
-            .r#type(QuantizationType::Int8.into())
-            .quantile(0.99)
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::Binary => BinaryQuantizationBuilder::new(always_ram).into(),
-        QuantKind::Binary2bit => BinaryQuantizationBuilder::new(always_ram)
-            .encoding(BinaryQuantizationEncoding::TwoBits)
-            .into(),
-        QuantKind::Binary15bit => BinaryQuantizationBuilder::new(always_ram)
-            .encoding(BinaryQuantizationEncoding::OneAndHalfBits)
-            .into(),
-        QuantKind::Turbo1bit => TurboQuantizationBuilder::new()
-            .bits(TurboQuantBitSize::Bits1)
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::Turbo15bit => TurboQuantizationBuilder::new()
-            .bits(TurboQuantBitSize::Bits15)
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::Turbo2bit => TurboQuantizationBuilder::new()
-            .bits(TurboQuantBitSize::Bits2)
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::Turbo4bit => TurboQuantizationBuilder::new()
-            .bits(TurboQuantBitSize::Bits4)
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::ProductX4 => ProductQuantizationBuilder::new(CompressionRatio::X4.into())
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::ProductX8 => ProductQuantizationBuilder::new(CompressionRatio::X8.into())
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::ProductX16 => ProductQuantizationBuilder::new(CompressionRatio::X16.into())
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::ProductX32 => ProductQuantizationBuilder::new(CompressionRatio::X32.into())
-            .always_ram(always_ram)
-            .into(),
-        QuantKind::ProductX64 => ProductQuantizationBuilder::new(CompressionRatio::X64.into())
-            .always_ram(always_ram)
-            .into(),
+        QuantKind::Scalar => {
+            let mut builder = ScalarQuantizationBuilder::default()
+                .r#type(QuantizationType::Int8.into())
+                .quantile(0.99)
+                .always_ram(always_ram);
+            if let Some(memory) = memory {
+                builder = builder.memory(memory_to_i32(memory));
+            }
+            builder.into()
+        }
+        QuantKind::Binary | QuantKind::Binary2bit | QuantKind::Binary15bit => {
+            let mut builder = BinaryQuantizationBuilder::new(always_ram);
+            builder = match kind {
+                QuantKind::Binary2bit => builder.encoding(BinaryQuantizationEncoding::TwoBits),
+                QuantKind::Binary15bit => {
+                    builder.encoding(BinaryQuantizationEncoding::OneAndHalfBits)
+                }
+                _ => builder,
+            };
+            if let Some(memory) = memory {
+                builder = builder.memory(memory_to_i32(memory));
+            }
+            builder.into()
+        }
+        QuantKind::Turbo1bit
+        | QuantKind::Turbo15bit
+        | QuantKind::Turbo2bit
+        | QuantKind::Turbo4bit => {
+            let bits = match kind {
+                QuantKind::Turbo1bit => TurboQuantBitSize::Bits1,
+                QuantKind::Turbo15bit => TurboQuantBitSize::Bits15,
+                QuantKind::Turbo2bit => TurboQuantBitSize::Bits2,
+                _ => TurboQuantBitSize::Bits4,
+            };
+            let mut builder = TurboQuantizationBuilder::new()
+                .bits(bits)
+                .always_ram(always_ram);
+            if let Some(memory) = memory {
+                builder = builder.memory(memory_to_i32(memory));
+            }
+            builder.into()
+        }
+        QuantKind::ProductX4
+        | QuantKind::ProductX8
+        | QuantKind::ProductX16
+        | QuantKind::ProductX32
+        | QuantKind::ProductX64 => {
+            let compression = match kind {
+                QuantKind::ProductX4 => CompressionRatio::X4,
+                QuantKind::ProductX8 => CompressionRatio::X8,
+                QuantKind::ProductX16 => CompressionRatio::X16,
+                QuantKind::ProductX32 => CompressionRatio::X32,
+                _ => CompressionRatio::X64,
+            };
+            let mut builder =
+                ProductQuantizationBuilder::new(compression.into()).always_ram(always_ram);
+            if let Some(memory) = memory {
+                builder = builder.memory(memory_to_i32(memory));
+            }
+            builder.into()
+        }
     };
     Some(config)
 }
 
 fn build_vector_params(vc: &VectorConfig) -> VectorParams {
-    VectorParams {
-        size: vc.size,
-        distance: distance_to_i32(vc.distance),
-        on_disk: vc.on_disk,
-        multivector_config: vc.multivector.as_ref().map(|mv| {
-            let comparator = match mv.comparator {
-                ComparatorKind::MaxSim => MultiVectorComparator::MaxSim,
-            };
-            MultiVectorConfigBuilder::new(comparator).build()
-        }),
-        datatype: Some(datatype_to_i32(vc.datatype)),
-        quantization_config: vc
-            .quantization
-            .as_ref()
-            .and_then(|q| build_quantization_config(q.kind, q.always_ram))
-            .map(Into::into),
-        ..Default::default()
+    let mut builder = VectorParamsBuilder::new(vc.size, distance_to_grpc(vc.distance))
+        .datatype(datatype_to_i32(vc.datatype));
+
+    if let Some(on_disk) = vc.on_disk {
+        builder = builder.on_disk(on_disk);
     }
+    if let Some(memory) = vc.memory {
+        builder = builder.memory(memory_to_i32(memory));
+    }
+    if let Some(mv) = &vc.multivector {
+        let comparator = match mv.comparator {
+            ComparatorKind::MaxSim => MultiVectorComparator::MaxSim,
+        };
+        builder = builder.multivector_config(MultiVectorConfigBuilder::new(comparator));
+    }
+    if let Some(quantization) = vc
+        .quantization
+        .as_ref()
+        .and_then(|q| build_quantization_config(q.kind, q.always_ram, q.memory))
+    {
+        builder = builder.quantization_config(quantization);
+    }
+
+    builder.build()
 }
 
 pub async fn recreate_collection_from_config(
@@ -176,15 +222,17 @@ pub async fn recreate_collection_from_config(
             .sparse_vectors
             .iter()
             .map(|sc| {
-                let index_builder = SparseIndexConfigBuilder::default()
+                let mut index_builder = SparseIndexConfigBuilder::default()
                     .on_disk(sc.on_disk)
                     .datatype(datatype_to_i32(sc.datatype));
-                (
-                    sc.name.clone(),
-                    SparseVectorParamsBuilder::default()
-                        .index(index_builder)
-                        .build(),
-                )
+                if let Some(memory) = sc.memory {
+                    index_builder = index_builder.memory(memory_to_i32(memory));
+                }
+                let mut params = SparseVectorParamsBuilder::default().index(index_builder);
+                if let Some(modifier) = modifier_to_grpc(sc.modifier) {
+                    params = params.modifier(modifier);
+                }
+                (sc.name.clone(), params.build())
             })
             .collect();
         Some(SparseVectorConfig::from(params))
@@ -205,11 +253,18 @@ pub async fn recreate_collection_from_config(
     if let Some(shard_number) = collection.shard_number {
         create_collection_builder = create_collection_builder.shard_number(shard_number);
     }
+    if let Some(memory) = collection.payload.memory {
+        create_collection_builder = create_collection_builder
+            .payload(PayloadStorageParamsBuilder::default().memory(memory_to_i32(memory)));
+    }
 
     if let Some(hnsw) = &collection.hnsw {
         let mut hnsw_config = HnswConfigDiffBuilder::default()
             .on_disk(hnsw.on_disk)
             .inline_storage(hnsw.inline_storage);
+        if let Some(memory) = hnsw.memory {
+            hnsw_config = hnsw_config.memory(memory_to_i32(memory));
+        }
         if let Some(m) = hnsw.m {
             hnsw_config = hnsw_config.m(m);
         }
@@ -246,7 +301,8 @@ pub async fn recreate_collection_from_config(
     }
 
     if let Some(quant) = &collection.quantization
-        && let Some(quant_config) = build_quantization_config(quant.kind, quant.always_ram)
+        && let Some(quant_config) =
+            build_quantization_config(quant.kind, quant.always_ram, quant.memory)
     {
         create_collection_builder = create_collection_builder.quantization_config(quant_config);
     }
@@ -297,52 +353,77 @@ async fn create_field_indices_from_config(
         let name = config.collection.name.clone();
         let field = pc.name.clone();
 
+        // `memory` supersedes `on_disk` on servers that understand it; both are
+        // sent so the config keeps working against older ones.
+        let memory = pc.memory.map(memory_to_i32);
+
         let builder = match pc.kind {
             PayloadType::Keyword => {
+                let mut params = KeywordIndexParamsBuilder::default()
+                    .on_disk(pc.on_disk)
+                    .is_tenant(pc.is_tenant)
+                    .prefix(pc.prefix);
+                if let Some(memory) = memory {
+                    params = params.memory(memory);
+                }
                 CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Keyword)
-                    .field_index_params(
-                        KeywordIndexParamsBuilder::default()
-                            .on_disk(pc.on_disk)
-                            .is_tenant(pc.is_tenant),
-                    )
+                    .field_index_params(params)
             }
             PayloadType::Integer => {
+                let mut params = IntegerIndexParamsBuilder::new(true, pc.range_index)
+                    .on_disk(pc.on_disk)
+                    .is_principal(pc.is_principal);
+                if let Some(memory) = memory {
+                    params = params.memory(memory);
+                }
                 CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Integer)
-                    .field_index_params(
-                        IntegerIndexParamsBuilder::new(true, pc.range_index)
-                            .on_disk(pc.on_disk)
-                            .is_principal(pc.is_principal),
-                    )
+                    .field_index_params(params)
             }
             PayloadType::Float => {
+                let mut params = FloatIndexParamsBuilder::default()
+                    .on_disk(pc.on_disk)
+                    .is_principal(pc.is_principal);
+                if let Some(memory) = memory {
+                    params = params.memory(memory);
+                }
                 CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Float)
-                    .field_index_params(
-                        FloatIndexParamsBuilder::default()
-                            .on_disk(pc.on_disk)
-                            .is_principal(pc.is_principal),
-                    )
+                    .field_index_params(params)
             }
             PayloadType::Bool => {
+                let mut params = BoolIndexParamsBuilder::default().on_disk(pc.on_disk);
+                if let Some(memory) = memory {
+                    params = params.memory(memory);
+                }
                 CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Bool)
-                    .field_index_params(BoolIndexParamsBuilder::default().on_disk(pc.on_disk))
+                    .field_index_params(params)
             }
             PayloadType::Uuid => {
+                let mut params = UuidIndexParamsBuilder::default()
+                    .is_tenant(pc.is_tenant)
+                    .on_disk(pc.on_disk);
+                if let Some(memory) = memory {
+                    params = params.memory(memory);
+                }
                 CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Uuid)
-                    .field_index_params(
-                        UuidIndexParamsBuilder::default()
-                            .is_tenant(pc.is_tenant)
-                            .on_disk(pc.on_disk),
-                    )
+                    .field_index_params(params)
             }
-            PayloadType::Geo => CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Geo)
-                .field_index_params(GeoIndexParamsBuilder::new().on_disk(pc.on_disk)),
+            PayloadType::Geo => {
+                let mut params = GeoIndexParamsBuilder::new().on_disk(pc.on_disk);
+                if let Some(memory) = memory {
+                    params = params.memory(memory);
+                }
+                CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Geo)
+                    .field_index_params(params)
+            }
             PayloadType::Datetime => {
+                let mut params = DatetimeIndexParamsBuilder::default()
+                    .on_disk(pc.on_disk)
+                    .is_principal(pc.is_principal);
+                if let Some(memory) = memory {
+                    params = params.memory(memory);
+                }
                 CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Datetime)
-                    .field_index_params(
-                        DatetimeIndexParamsBuilder::default()
-                            .on_disk(pc.on_disk)
-                            .is_principal(pc.is_principal),
-                    )
+                    .field_index_params(params)
             }
             PayloadType::Text => {
                 let tokenizer = match pc.tokenizer.unwrap_or(TokenizerKind::Word) {
@@ -351,8 +432,12 @@ async fn create_field_indices_from_config(
                     TokenizerKind::Prefix => TokenizerType::Prefix,
                     TokenizerKind::Multilingual => TokenizerType::Multilingual,
                 };
+                let mut params = TextIndexParamsBuilder::new(tokenizer).on_disk(pc.on_disk);
+                if let Some(memory) = memory {
+                    params = params.memory(memory);
+                }
                 CreateFieldIndexCollectionBuilder::new(name, field, FieldType::Text)
-                    .field_index_params(TextIndexParamsBuilder::new(tokenizer).on_disk(pc.on_disk))
+                    .field_index_params(params)
             }
         };
 
@@ -373,18 +458,12 @@ mod tests {
 
     #[test]
     fn distance_mapping() {
+        assert_eq!(distance_to_grpc(DistanceKind::Cosine), Distance::Cosine);
+        assert_eq!(distance_to_grpc(DistanceKind::Dot), Distance::Dot);
+        assert_eq!(distance_to_grpc(DistanceKind::Euclid), Distance::Euclid);
         assert_eq!(
-            distance_to_i32(DistanceKind::Cosine),
-            Distance::Cosine as i32
-        );
-        assert_eq!(distance_to_i32(DistanceKind::Dot), Distance::Dot as i32);
-        assert_eq!(
-            distance_to_i32(DistanceKind::Euclid),
-            Distance::Euclid as i32
-        );
-        assert_eq!(
-            distance_to_i32(DistanceKind::Manhattan),
-            Distance::Manhattan as i32
+            distance_to_grpc(DistanceKind::Manhattan),
+            Distance::Manhattan
         );
     }
 
@@ -399,19 +478,75 @@ mod tests {
             Datatype::Float16 as i32
         );
         assert_eq!(datatype_to_i32(DatatypeKind::Uint8), Datatype::Uint8 as i32);
+        assert_eq!(
+            datatype_to_i32(DatatypeKind::Turbo4),
+            Datatype::Turbo4 as i32
+        );
+    }
+
+    #[test]
+    fn memory_mapping() {
+        assert_eq!(memory_to_i32(MemoryKind::Cold), Memory::Cold as i32);
+        assert_eq!(memory_to_i32(MemoryKind::Cached), Memory::Cached as i32);
+        assert_eq!(memory_to_i32(MemoryKind::Pinned), Memory::Pinned as i32);
     }
 
     #[test]
     fn quantization_none_is_none() {
-        assert!(build_quantization_config(QuantKind::None, true).is_none());
+        assert!(build_quantization_config(QuantKind::None, true, None).is_none());
     }
 
     #[test]
     fn quantization_variants_build() {
-        assert!(build_quantization_config(QuantKind::Scalar, true).is_some());
-        assert!(build_quantization_config(QuantKind::Binary, false).is_some());
-        assert!(build_quantization_config(QuantKind::ProductX8, false).is_some());
-        assert!(build_quantization_config(QuantKind::Turbo4bit, true).is_some());
+        assert!(build_quantization_config(QuantKind::Scalar, true, None).is_some());
+        assert!(build_quantization_config(QuantKind::Binary, false, None).is_some());
+        assert!(build_quantization_config(QuantKind::ProductX8, false, None).is_some());
+        assert!(build_quantization_config(QuantKind::Turbo4bit, true, None).is_some());
+    }
+
+    /// Every quantization kind must carry `memory` through to the gRPC message.
+    #[test]
+    fn quantization_memory_is_passed_through() {
+        use qdrant_client::qdrant::quantization_config::Quantization;
+
+        let expected = Memory::Pinned as i32;
+        for kind in [
+            QuantKind::Scalar,
+            QuantKind::Binary,
+            QuantKind::Binary2bit,
+            QuantKind::Binary15bit,
+            QuantKind::Turbo1bit,
+            QuantKind::Turbo15bit,
+            QuantKind::Turbo2bit,
+            QuantKind::Turbo4bit,
+            QuantKind::ProductX4,
+            QuantKind::ProductX8,
+            QuantKind::ProductX16,
+            QuantKind::ProductX32,
+            QuantKind::ProductX64,
+        ] {
+            let config = build_quantization_config(kind, false, Some(MemoryKind::Pinned)).unwrap();
+            let memory = match config {
+                Quantization::Scalar(q) => q.memory,
+                Quantization::Binary(q) => q.memory,
+                Quantization::Turboquant(q) => q.memory,
+                Quantization::Product(q) => q.memory,
+            };
+            assert_eq!(memory, Some(expected), "{kind:?} dropped `memory`");
+        }
+    }
+
+    #[test]
+    fn vector_params_carry_memory_and_on_disk() {
+        let vc = vector_config(
+            "collection:\n  vectors:\n    - size: 8\n      on_disk: true\n      memory: cached\n",
+        );
+        let params = build_vector_params(&vc);
+        assert_eq!(params.memory, Some(Memory::Cached as i32));
+        #[expect(deprecated)]
+        {
+            assert_eq!(params.on_disk, Some(true));
+        }
     }
 
     #[test]

--- a/src/config/collection.rs
+++ b/src/config/collection.rs
@@ -46,6 +46,9 @@ pub struct PayloadSection {
     /// their own `source`); fields not listed are uploaded but left unindexed.
     #[serde(default)]
     pub source: Option<PayloadSource>,
+    /// Memory placement of the payload storage. Supersedes `on_disk_payload`.
+    #[serde(default)]
+    pub memory: Option<MemoryKind>,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
@@ -54,6 +57,22 @@ pub enum IdType {
     #[default]
     Integer,
     Uuid,
+}
+
+/// Memory placement of a component's data (Qdrant 1.19+). Data is always
+/// persisted on disk; this only controls how it is held in RAM. Supersedes the
+/// older `on_disk` / `always_ram` booleans, which stay available for older
+/// servers — when both are given, `memory` wins.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryKind {
+    /// Not pre-loaded from disk; cached with usage.
+    Cold,
+    /// Pre-loaded into disk-cache RAM on start, may be evicted under pressure.
+    Cached,
+    /// Loaded in RAM and never evicted. Unsupported for dense vector storage
+    /// and payload storage.
+    Pinned,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,6 +94,9 @@ pub struct HnswConfig {
     pub on_disk: bool,
     #[serde(default)]
     pub inline_storage: bool,
+    /// Memory placement of the HNSW graph. Supersedes `on_disk`.
+    #[serde(default)]
+    pub memory: Option<MemoryKind>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -95,6 +117,9 @@ pub struct QuantizationConfig {
     pub kind: QuantKind,
     #[serde(default)]
     pub always_ram: bool,
+    /// Memory placement of the quantized vectors. Supersedes `always_ram`.
+    #[serde(default)]
+    pub memory: Option<MemoryKind>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,11 +13,11 @@ pub mod scroll;
 pub mod search;
 pub mod vector;
 
-pub use collection::{CollectionConfig, IdType, QuantKind};
+pub use collection::{CollectionConfig, IdType, MemoryKind, QuantKind};
 pub use payload::{PayloadSource, PayloadSourceKind, PayloadType, TokenizerKind};
 pub use vector::{
-    ComparatorKind, DatatypeKind, DistanceKind, DistributionKind, FileStrategy, SparseKind,
-    SparseSource, VectorConfig, VectorSource,
+    ComparatorKind, DatatypeKind, DistanceKind, DistributionKind, FileStrategy, ModifierKind,
+    SparseKind, SparseSource, VectorConfig, VectorSource,
 };
 
 use std::fmt;
@@ -472,6 +472,28 @@ collection:
         assert_eq!(p.kind, PayloadType::Float);
         assert!(p.index);
         assert!(p.source.is_none());
+    }
+
+    /// The shipped example advertises every knob; keep it loadable so a config
+    /// copied out of it actually works.
+    #[test]
+    fn parses_upload_config_example() {
+        let cfg = super::load("examples/upload-config.yaml").unwrap();
+        assert_eq!(
+            cfg.collection.payload.memory,
+            Some(crate::config::MemoryKind::Cached)
+        );
+        assert_eq!(
+            cfg.collection.hnsw.as_ref().unwrap().memory,
+            Some(crate::config::MemoryKind::Cold)
+        );
+        let color = cfg
+            .collection
+            .fields
+            .iter()
+            .find(|f| f.name == "color")
+            .unwrap();
+        assert!(color.prefix);
     }
 
     #[test]

--- a/src/config/payload.rs
+++ b/src/config/payload.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+use super::collection::MemoryKind;
 use super::vector::DistributionKind;
 use super::{default_true, option_string_or_struct};
 use crate::dataset::DatasetConfig;
@@ -19,6 +20,9 @@ pub struct PayloadConfig {
     pub index: bool,
     #[serde(default)]
     pub on_disk: bool,
+    /// Memory placement of the field index. Supersedes `on_disk`.
+    #[serde(default)]
+    pub memory: Option<MemoryKind>,
     #[serde(default)]
     pub is_tenant: bool,
     #[serde(default)]
@@ -26,6 +30,10 @@ pub struct PayloadConfig {
     /// Integer payloads: also build a range index.
     #[serde(default = "default_true")]
     pub range_index: bool,
+    /// Keyword payloads: build the index with prefix matching enabled, so
+    /// searches may use `match_prefix` filters on this field.
+    #[serde(default)]
+    pub prefix: bool,
     /// Text payloads: tokenizer.
     pub tokenizer: Option<TokenizerKind>,
     /// Per-field value source. May be omitted when `collection.payload.source`

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -22,6 +22,14 @@ const SCHEMA_REFERENCE: &str = r#"# bfb upload-config file schema (`bfb upload -
 #
 # Legend:  <type>  default=<value>  [allowed | values]   (Option ⇒ optional)
 # Unknown fields are rejected. At least one dense or sparse vector is required.
+#
+# `memory:` (Qdrant 1.19+) is accepted wherever an `on_disk` / `always_ram`
+# boolean is, and supersedes it when the server understands it:
+#   cold    data is not pre-loaded from disk to RAM; cached with usage
+#   cached  pre-loaded into disk-cache RAM on start, may be evicted under pressure
+#   pinned  loaded in RAM and never evicted (not supported for dense vectors
+#           or the payload storage)
+# Both are sent, so configs stay usable against older servers.
 
 collection:
   name: benchmark                # string         default="benchmark"  collection name
@@ -44,6 +52,7 @@ collection:
     full_scan_threshold: null    # uint64         optional
     on_disk: false               # bool           default=false        store HNSW graph on disk
     inline_storage: false        # bool           default=false
+    memory: null                 # enum           optional             [cold | cached | pinned] supersedes `on_disk`
 
   # Optimizer parameters (optional).
   optimizers:
@@ -60,6 +69,7 @@ collection:
                                  #   turbo-2bit | turbo-4bit | product-x4 | product-x8 |
                                  #   product-x16 | product-x32 | product-x64]
     always_ram: false            # bool           default=false        keep quantized vectors in RAM
+    memory: null                 # enum           optional             [cold | cached | pinned] supersedes `always_ram`
 
   # Dense vectors. At most one may omit `name` (the unnamed default vector);
   # otherwise every entry must have a unique `name`.
@@ -67,8 +77,9 @@ collection:
     - name: image                # string         optional             omit for the unnamed default vector
       size: 512                  # uint64         required             dimensionality
       distance: cosine           # enum           default=cosine       [cosine | dot | euclid | manhattan]
-      datatype: float32          # enum           default=float32      [float32 | float16 | uint8]
+      datatype: float32          # enum           default=float32      [float32 | float16 | uint8 | turbo4]
       on_disk: null              # bool           optional             store vectors on disk
+      memory: null               # enum           optional             [cold | cached] supersedes `on_disk`
       quantization: null         # map            optional             same shape as `collection.quantization`
       # Multivectors (optional): generate several sub-vectors per point.
       multivector:
@@ -94,6 +105,9 @@ collection:
     - name: bm25                 # string         required
       datatype: float32          # enum           default=float32      [float32 | float16 | uint8]
       on_disk: false             # bool           default=false
+      memory: null               # enum           optional             [cold | cached | pinned] supersedes `on_disk`
+      modifier: none             # enum           default=none         [none | idf] `idf` enables BM25-style
+                                 #   scoring, and is required by search `idf_corpus`
       # Value source. Shorthand string `random`, or a map:
       source:
         type: random             # enum           default=random       [random | dataset]
@@ -114,6 +128,7 @@ collection:
   # fields to index (and may omit their own `source`); fields present in the
   # object but not listed are uploaded but left unindexed.
   payload:
+    memory: null                 # enum           optional             [cold | cached] supersedes `on_disk_payload`
     source: null                 # optional            whole-payload dataset source, e.g.:
     #   type: dataset
     #   dataset:
@@ -130,9 +145,12 @@ collection:
                                  #   bool | uuid | geo | text | datetime]
       index: true                # bool           default=true         build a field index (false ⇒ filler)
       on_disk: false             # bool           default=false        store the index on disk
+      memory: null               # enum           optional             [cold | cached | pinned] supersedes `on_disk`
       is_tenant: false           # bool           default=false        tenant-isolating index
       is_principal: false        # bool           default=false        principal (primary) index
       range_index: true          # bool           default=true         integer payloads: also build a range index
+      prefix: false              # bool           default=false        keyword payloads: enable prefix matching
+                                 #   (required for search `match_prefix` filters)
       tokenizer: null            # enum           optional (text)      [word | whitespace | prefix | multilingual]
       # Value source (optional when `payload.source` is set — then the entry is
       # index-only). Shorthand string `random` / `random-clusters` / `now`, or a
@@ -183,6 +201,7 @@ mod tests {
                     full_scan_threshold: Some(10000),
                     on_disk: false,
                     inline_storage: false,
+                    memory: Some(MemoryKind::Cached),
                 }),
                 optimizers: Some(OptimizersConfig {
                     default_segment_number: Some(2),
@@ -194,6 +213,7 @@ mod tests {
                 quantization: Some(QuantizationConfig {
                     kind: QuantKind::Scalar,
                     always_ram: false,
+                    memory: Some(MemoryKind::Pinned),
                 }),
                 vectors: vec![VectorConfig {
                     name: Some("image".to_string()),
@@ -201,6 +221,7 @@ mod tests {
                     distance: DistanceKind::Cosine,
                     datatype: DatatypeKind::Float32,
                     on_disk: Some(false),
+                    memory: Some(MemoryKind::Cached),
                     multivector: Some(MultivectorConfig {
                         comparator: ComparatorKind::MaxSim,
                         count: 4,
@@ -208,6 +229,7 @@ mod tests {
                     quantization: Some(QuantizationConfig {
                         kind: QuantKind::Scalar,
                         always_ram: false,
+                        memory: Some(MemoryKind::Pinned),
                     }),
                     // File source so `path`/`strategy` are exercised too;
                     // a remote path keeps `validate()` from checking existence.
@@ -220,6 +242,8 @@ mod tests {
                     name: "bm25".to_string(),
                     datatype: DatatypeKind::Float32,
                     on_disk: false,
+                    memory: Some(MemoryKind::Cached),
+                    modifier: ModifierKind::Idf,
                     source: SparseSource {
                         kind: SparseKind::Random,
                         vocab_size: 1000,
@@ -228,15 +252,20 @@ mod tests {
                         dataset: None,
                     },
                 }],
-                payload: PayloadSection { source: None },
+                payload: PayloadSection {
+                    source: None,
+                    memory: Some(MemoryKind::Cached),
+                },
                 fields: vec![PayloadConfig {
                     name: "color".to_string(),
                     kind: PayloadType::Keyword,
                     index: true,
                     on_disk: false,
+                    memory: Some(MemoryKind::Cached),
                     is_tenant: false,
                     is_principal: false,
                     range_index: true,
+                    prefix: true,
                     tokenizer: Some(TokenizerKind::Word),
                     source: Some(PayloadSource {
                         kind: PayloadSourceKind::Random,

--- a/src/config/scroll.rs
+++ b/src/config/scroll.rs
@@ -58,6 +58,11 @@ impl ScrollConfig {
         if self.requests.is_empty() {
             bail!("scroll config must declare at least one entry under `requests`");
         }
+        for (index, request) in self.requests.iter().enumerate() {
+            for filter in &request.filters {
+                filter.validate(&format!("requests[{index}]"))?;
+            }
+        }
         Ok(())
     }
 }

--- a/src/config/search.rs
+++ b/src/config/search.rs
@@ -54,6 +54,12 @@ pub enum SearchRequestConfig {
         source: SparseSource,
         #[serde(default)]
         filters: Vec<FilterPayloadConfig>,
+        /// IDF corpus (Qdrant 1.19+): restricts the population sparse-vector IDF
+        /// statistics are computed over to the points matching these conditions.
+        /// Empty ⇒ collection-wide (global) statistics. Only meaningful for
+        /// sparse vectors created with the IDF modifier.
+        #[serde(default)]
+        idf_corpus: Vec<FilterPayloadConfig>,
     },
 }
 
@@ -68,6 +74,24 @@ pub struct FilterPayloadConfig {
     pub source: PayloadSource,
     /// Keyword filters: match any of N random values instead of one.
     pub match_any: Option<usize>,
+    /// Keyword filters: match a prefix of this many characters instead of a
+    /// whole value. Requires the field's keyword index to be created with
+    /// `prefix: true`. Takes precedence over `match_any`.
+    pub match_prefix: Option<usize>,
+}
+
+impl FilterPayloadConfig {
+    /// Validate one filter condition. `context` names where it came from, e.g.
+    /// `"requests[0]"` or `"requests[0].idf_corpus"`.
+    pub fn validate(&self, context: &str) -> Result<()> {
+        if self.match_prefix.is_some() && self.kind != PayloadType::Keyword {
+            bail!("{context}: `match_prefix` only applies to `type: keyword` filters");
+        }
+        if self.match_prefix == Some(0) {
+            bail!("{context}: `match_prefix` must be > 0");
+        }
+        Ok(())
+    }
 }
 
 /// Read and validate a YAML search config file.
@@ -95,7 +119,24 @@ impl SearchConfig {
 }
 
 impl SearchRequestConfig {
+    /// Payload conditions applied to the query itself.
+    pub fn filters(&self) -> &[FilterPayloadConfig] {
+        match self {
+            SearchRequestConfig::Dense { filters, .. }
+            | SearchRequestConfig::Sparse { filters, .. } => filters,
+        }
+    }
+
     fn validate(&self, index: usize) -> Result<()> {
+        for filter in self.filters() {
+            filter.validate(&format!("requests[{index}]"))?;
+        }
+        if let SearchRequestConfig::Sparse { idf_corpus, .. } = self {
+            for filter in idf_corpus {
+                filter.validate(&format!("requests[{index}].idf_corpus"))?;
+            }
+        }
+
         match self {
             SearchRequestConfig::Dense { size, source, .. } => {
                 match source {
@@ -274,6 +315,109 @@ requests:
             .unwrap_err()
             .to_string();
         assert!(err.contains("requests[0]"), "{err}");
+    }
+
+    #[test]
+    fn parses_match_prefix_and_idf_corpus() {
+        let yaml = r#"
+collection:
+  name: bench
+requests:
+  - kind: sparse
+    using: bm25
+    filters:
+      - name: color
+        type: keyword
+        source: { cardinality: 100 }
+        match_prefix: 9
+    idf_corpus:
+      - name: tenant
+        type: keyword
+        source: { cardinality: 10 }
+"#;
+        let cfg: SearchConfig = serde_yaml::from_str(yaml).unwrap();
+        cfg.validate().unwrap();
+        match &cfg.requests[0] {
+            SearchRequestConfig::Sparse {
+                filters,
+                idf_corpus,
+                ..
+            } => {
+                assert_eq!(filters[0].match_prefix, Some(9));
+                assert_eq!(idf_corpus.len(), 1);
+                assert_eq!(idf_corpus[0].name, "tenant");
+            }
+            _ => panic!("expected sparse request"),
+        }
+    }
+
+    #[test]
+    fn rejects_match_prefix_on_non_keyword_field() {
+        let yaml = r#"
+collection:
+  name: bench
+requests:
+  - kind: dense
+    size: 4
+    filters:
+      - name: age
+        type: integer
+        match_prefix: 3
+"#;
+        let cfg: SearchConfig = serde_yaml::from_str(yaml).unwrap();
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(err.contains("match_prefix"), "{err}");
+    }
+
+    #[test]
+    fn rejects_zero_length_match_prefix() {
+        let yaml = r#"
+collection:
+  name: bench
+requests:
+  - kind: dense
+    size: 4
+    filters:
+      - name: color
+        type: keyword
+        match_prefix: 0
+"#;
+        let cfg: SearchConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_idf_corpus_on_dense_requests() {
+        let yaml = r#"
+collection:
+  name: bench
+requests:
+  - kind: dense
+    size: 4
+    idf_corpus: []
+"#;
+        assert!(serde_yaml::from_str::<SearchConfig>(yaml).is_err());
+    }
+
+    /// Same contract as the upload example: the shipped search config must stay
+    /// loadable.
+    #[test]
+    fn parses_search_config_example() {
+        let cfg = super::load("examples/search-config.yaml").unwrap();
+        assert!(
+            cfg.requests.iter().any(|r| matches!(
+                r,
+                SearchRequestConfig::Sparse { idf_corpus, .. } if !idf_corpus.is_empty()
+            )),
+            "example lost its idf_corpus request"
+        );
+        assert!(
+            cfg.requests
+                .iter()
+                .flat_map(SearchRequestConfig::filters)
+                .any(|f| f.match_prefix.is_some()),
+            "example lost its match_prefix filter"
+        );
     }
 
     #[test]

--- a/src/config/vector.rs
+++ b/src/config/vector.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use super::collection::QuantizationConfig;
+use super::collection::{MemoryKind, QuantizationConfig};
 use super::string_or_struct;
 use crate::dataset::DatasetConfig;
 
@@ -22,6 +22,10 @@ pub struct VectorConfig {
     #[serde(default)]
     pub datatype: DatatypeKind,
     pub on_disk: Option<bool>,
+    /// Memory placement of the vector storage. Supersedes `on_disk`.
+    /// `pinned` is not supported for dense vectors.
+    #[serde(default)]
+    pub memory: Option<MemoryKind>,
     pub multivector: Option<MultivectorConfig>,
     pub quantization: Option<QuantizationConfig>,
     #[serde(default, deserialize_with = "string_or_struct")]
@@ -45,6 +49,8 @@ pub enum DatatypeKind {
     Float32,
     Float16,
     Uint8,
+    /// 4-bit turbo-quantized storage (Qdrant 1.19+). Dense vectors only.
+    Turbo4,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -110,8 +116,25 @@ pub struct SparseVectorConfig {
     pub datatype: DatatypeKind,
     #[serde(default)]
     pub on_disk: bool,
+    /// Memory placement of the sparse inverted index. Supersedes `on_disk`.
+    #[serde(default)]
+    pub memory: Option<MemoryKind>,
+    /// Value modifier applied at query time. `idf` is required for BM25-style
+    /// scoring and for search requests that set an `idf_corpus`.
+    #[serde(default)]
+    pub modifier: ModifierKind,
     #[serde(default, deserialize_with = "string_or_struct")]
     pub source: SparseSource,
+}
+
+/// Modifier applied to sparse vector values.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModifierKind {
+    #[default]
+    None,
+    /// Inverse document frequency.
+    Idf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/generators/queries.rs
+++ b/src/generators/queries.rs
@@ -38,6 +38,9 @@ pub struct GeneratedQuery {
     pub dense: Option<(Vec<f32>, Option<String>)>,
     pub sparse: Option<(Vec<f32>, SparseIndices, String)>,
     pub filter: Option<Filter>,
+    /// Sparse-vector IDF corpus: restricts which points the IDF statistics are
+    /// computed over. `None` ⇒ collection-wide (global) statistics.
+    pub idf_corpus: Option<Filter>,
     /// Ground-truth nearest-neighbor point ids for this query, present only
     /// when the request draws queries from a reference dataset. Used to measure
     /// search accuracy (recall) against the dataset's known answers.
@@ -65,6 +68,8 @@ struct RequestState {
     query_dataset: Option<QueryDataset>,
     sparse_zipf: Option<rand_distr::Zipf<f64>>,
     filters: FilterGenerator,
+    /// Sparse requests only: conditions defining the IDF corpus.
+    idf_corpus: FilterGenerator,
 }
 
 /// Builds a random payload filter from a list of [`FilterPayloadConfig`].
@@ -133,7 +138,13 @@ impl FilterGenerator {
                 PayloadType::Keyword => {
                     let card = src.cardinality.unwrap_or(100);
                     let mult = src.length_multiplier.unwrap_or(1);
-                    let condition = if let Some(match_any) = fp.match_any {
+                    let condition = if let Some(len) = fp.match_prefix {
+                        // Truncate a generated value: shorter prefixes match more
+                        // keywords, which is the selectivity knob here.
+                        let keyword = random_keyword(rng, card, mult);
+                        let prefix: String = keyword.chars().take(len).collect();
+                        MatchValue::Prefix(prefix)
+                    } else if let Some(match_any) = fp.match_any {
                         MatchValue::Keywords(RepeatedStrings {
                             strings: (0..match_any)
                                 .map(|_| random_keyword(rng, card, mult))
@@ -260,7 +271,7 @@ impl ConfigSearchGenerator {
         let mut per_request = Vec::with_capacity(config.requests.len());
 
         for req in &config.requests {
-            let (dense_reader, query_dataset, sparse_zipf, filters) = match req {
+            let (dense_reader, query_dataset, sparse_zipf, filters, idf_corpus) = match req {
                 SearchRequestConfig::Dense {
                     source, filters, ..
                 } => {
@@ -274,10 +285,13 @@ impl ConfigSearchGenerator {
                         }
                         VectorSource::Random => (None, None),
                     };
-                    (dense_reader, query_dataset, None, filters)
+                    (dense_reader, query_dataset, None, filters, [].as_slice())
                 }
                 SearchRequestConfig::Sparse {
-                    source, filters, ..
+                    source,
+                    filters,
+                    idf_corpus,
+                    ..
                 } => {
                     if source.kind == SparseKind::Dataset {
                         let dataset = source
@@ -289,6 +303,7 @@ impl ConfigSearchGenerator {
                             Some(Self::open_query_dataset(dataset, datasets_dir)?),
                             None,
                             filters,
+                            idf_corpus.as_slice(),
                         )
                     } else {
                         (
@@ -297,6 +312,7 @@ impl ConfigSearchGenerator {
                             (source.distribution == DistributionKind::Zipf)
                                 .then(|| create_zipf(source.vocab_size)),
                             filters,
+                            idf_corpus.as_slice(),
                         )
                     }
                 }
@@ -307,6 +323,7 @@ impl ConfigSearchGenerator {
                 query_dataset,
                 sparse_zipf,
                 filters: FilterGenerator::new(filters, &mut rng),
+                idf_corpus: FilterGenerator::new(idf_corpus, &mut rng),
             });
         }
 
@@ -384,6 +401,7 @@ impl ConfigSearchGenerator {
                     dense: Some((vector, using.clone())),
                     sparse: None,
                     filter: state.filters.build(rng),
+                    idf_corpus: None,
                     expected_ids,
                 }
             }
@@ -391,6 +409,7 @@ impl ConfigSearchGenerator {
                 using,
                 source,
                 filters: _,
+                idf_corpus: _,
             } => {
                 let ((values, indices), expected_ids) =
                     if let Some(query_dataset) = &state.query_dataset {
@@ -405,6 +424,7 @@ impl ConfigSearchGenerator {
                     dense: None,
                     sparse: Some((values, indices, using.clone())),
                     filter: state.filters.build(rng),
+                    idf_corpus: state.idf_corpus.build(rng),
                     expected_ids,
                 }
             }
@@ -498,6 +518,8 @@ impl ConfigSearchGenerator {
 
 #[cfg(test)]
 mod tests {
+    use qdrant_client::qdrant::condition::ConditionOneOf;
+
     use super::*;
 
     fn build_gen(yaml: &str) -> ConfigSearchGenerator {
@@ -574,5 +596,58 @@ mod tests {
         let q = generator.make_query(0, &mut rng);
         assert!(q.filter.is_some());
         assert!(!q.filter.as_ref().unwrap().must.is_empty());
+    }
+
+    /// The generated condition matches a truncated keyword, so the prefix length
+    /// is the selectivity knob.
+    #[test]
+    fn match_prefix_truncates_the_generated_keyword() {
+        let generator = build_gen(
+            "collection:\n  name: x\nrequests:\n  - kind: dense\n    size: 4\n    filters:\n      - name: color\n        type: keyword\n        source: { cardinality: 500 }\n        match_prefix: 9\n",
+        );
+        let mut rng = rand::rng();
+
+        for _ in 0..20 {
+            let q = generator.make_query(0, &mut rng);
+            let condition = &q.filter.as_ref().unwrap().must[0];
+            let Some(ConditionOneOf::Field(field)) = &condition.condition_one_of else {
+                panic!("expected a field condition");
+            };
+            match &field.r#match.as_ref().unwrap().match_value {
+                // "keyword_<n>" truncated to its first 9 characters.
+                Some(MatchValue::Prefix(prefix)) => {
+                    assert_eq!(prefix.chars().count(), 9, "{prefix}");
+                    assert!(prefix.starts_with("keyword_"), "{prefix}");
+                }
+                other => panic!("expected a prefix match, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn idf_corpus_is_generated_for_sparse_requests_only() {
+        let generator = build_gen(
+            "collection:\n  name: x\nrequests:\n  - kind: sparse\n    using: bm25\n    source: { vocab_size: 32, length: 4 }\n    idf_corpus:\n      - name: tenant\n        type: keyword\n        source: { cardinality: 5 }\n  - kind: dense\n    size: 4\n",
+        );
+        let mut rng = rand::rng();
+
+        let sparse = generator.make_query_for(0, 0, &mut rng);
+        assert!(sparse.sparse.is_some());
+        assert_eq!(sparse.idf_corpus.as_ref().unwrap().must.len(), 1);
+        // The corpus is separate from the query filter, which stays unset here.
+        assert!(sparse.filter.is_none());
+
+        let dense = generator.make_query_for(1, 0, &mut rng);
+        assert!(dense.idf_corpus.is_none());
+    }
+
+    /// No `idf_corpus:` ⇒ no IDF params, i.e. collection-wide statistics.
+    #[test]
+    fn sparse_requests_have_no_idf_corpus_by_default() {
+        let generator = build_gen(
+            "collection:\n  name: x\nrequests:\n  - kind: sparse\n    using: bm25\n    source: { vocab_size: 32, length: 4 }\n",
+        );
+        let mut rng = rand::rng();
+        assert!(generator.make_query(0, &mut rng).idf_corpus.is_none());
     }
 }

--- a/src/search/from_args.rs
+++ b/src/search/from_args.rs
@@ -7,8 +7,9 @@ use indicatif::ProgressBar;
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::shard_key::Key;
 use qdrant_client::qdrant::{
-    PrefetchQueryBuilder, QuantizationSearchParamsBuilder, Query, QueryBatchPointsBuilder,
-    QueryPointsBuilder, SearchParamsBuilder, SparseIndices, VectorInput,
+    IdfParamsBuilder, PrefetchQueryBuilder, QuantizationSearchParamsBuilder, Query,
+    QueryBatchPointsBuilder, QueryPointsBuilder, SearchParams, SearchParamsBuilder, SparseIndices,
+    VectorInput,
 };
 use rand::Rng;
 use rand::RngExt;
@@ -233,6 +234,16 @@ impl SearchProcessor {
             search_params = search_params.hnsw_ef(hnsw_ef as u64);
         }
 
+        // Restrict sparse-vector IDF statistics to the filtered sub-corpus
+        // instead of the whole collection. Only valid on sparse queries — the
+        // server rejects `idf` on a dense vector.
+        if self.args.search_idf_corpus
+            && use_sparse
+            && let Some(filter) = &query_filter
+        {
+            search_params = search_params.idf(IdfParamsBuilder::default().corpus(filter.clone()));
+        }
+
         let query_points: Vec<_> = query_batch
             .into_iter()
             .map(|(query_vectors, sparse_indices, vector_name)| {
@@ -311,9 +322,17 @@ impl SearchProcessor {
             return Ok(());
         };
 
-        let exact_search = search_params.clone().exact(true).build();
+        // Flip only `exact`, so each query keeps its own params (notably its IDF
+        // corpus) and the reference results stay comparable.
+        let fallback = search_params.clone().exact(true).build();
         for point in &mut exact_query_points {
-            point.params = Some(exact_search);
+            point.params = Some(match point.params.take() {
+                Some(params) => SearchParams {
+                    exact: Some(true),
+                    ..params
+                },
+                None => fallback.clone(),
+            });
         }
         let mut exact_request_builder =
             QueryBatchPointsBuilder::new(self.args.collection_name.clone(), exact_query_points);

--- a/src/search/from_config.rs
+++ b/src/search/from_config.rs
@@ -7,8 +7,9 @@ use indicatif::ProgressBar;
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::shard_key::Key;
 use qdrant_client::qdrant::{
-    PrefetchQueryBuilder, QuantizationSearchParamsBuilder, Query, QueryBatchPointsBuilder,
-    QueryPointsBuilder, SearchParamsBuilder, SparseIndices, VectorInput,
+    IdfParamsBuilder, PrefetchQueryBuilder, QuantizationSearchParamsBuilder, Query,
+    QueryBatchPointsBuilder, QueryPointsBuilder, SearchParams, SearchParamsBuilder, SparseIndices,
+    VectorInput,
 };
 
 use super::{SearchStats, compare_batch_search_results, recall_against_ground_truth};
@@ -53,11 +54,18 @@ impl ConfigSearchProcessor {
     fn create_request_builder(
         &self,
         query_filter: Option<qdrant_client::qdrant::Filter>,
+        idf_corpus: Option<qdrant_client::qdrant::Filter>,
         query_vectors: Vec<f32>,
         sparse_indices: Option<SparseIndices>,
         vector_name: Option<String>,
-        search_params: SearchParamsBuilder,
+        mut search_params: SearchParamsBuilder,
     ) -> QueryPointsBuilder {
+        // Sparse IDF statistics are computed over this sub-corpus instead of the
+        // whole collection.
+        if let Some(corpus) = idf_corpus {
+            search_params = search_params.idf(IdfParamsBuilder::default().corpus(corpus));
+        }
+
         let mut request_builder = QueryPointsBuilder::new(self.args.collection_name.clone())
             .with_payload(self.args.search_with_payload)
             .with_vectors(self.args.search_with_vectors)
@@ -163,6 +171,7 @@ impl ConfigSearchProcessor {
             .into_iter()
             .map(|generated| {
                 let query_filter = generated.filter.clone();
+                let idf_corpus = generated.idf_corpus.clone();
                 let (query_vectors, sparse_indices, vector_name) =
                     if let Some((values, indices, name)) = generated.sparse {
                         (values, Some(indices), Some(name))
@@ -174,6 +183,7 @@ impl ConfigSearchProcessor {
 
                 self.create_request_builder(
                     query_filter,
+                    idf_corpus,
                     query_vectors,
                     sparse_indices,
                     vector_name,
@@ -270,9 +280,17 @@ impl ConfigSearchProcessor {
             return Ok(());
         };
 
-        let exact_search = search_params.clone().exact(true).build();
+        // Flip only `exact`, so each query keeps its own params (notably its IDF
+        // corpus) and the reference results stay comparable.
+        let fallback = search_params.clone().exact(true).build();
         for point in &mut exact_query_points {
-            point.params = Some(exact_search);
+            point.params = Some(match point.params.take() {
+                Some(params) => SearchParams {
+                    exact: Some(true),
+                    ..params
+                },
+                None => fallback.clone(),
+            });
         }
         let mut exact_request_builder =
             QueryBatchPointsBuilder::new(self.args.collection_name.clone(), exact_query_points);


### PR DESCRIPTION
Moves `qdrant-client` from the crates.io 1.18.0 release to the `dev` branch of `qdrant/rust-client` (pinned in `Cargo.lock` at `7382277`, the *Update rust client for 1.19* commit), and surfaces the new 1.19 options in both the YAML configs and the legacy flags.

## Collection config (upload)

| Option | Where |
|---|---|
| `memory: cold \| cached \| pinned` | `payload`, `hnsw`, `quantization`, `vectors[]`, `sparse_vectors[]`, `fields[]` |
| `datatype: turbo4` | dense vectors |
| `prefix: true` | keyword payload fields — builds a prefix-matching index |
| `modifier: none \| idf` | sparse vectors |

`memory` supersedes the `on_disk` / `always_ram` / `on_disk_payload` booleans but does not replace them — both are sent, so existing configs keep working against pre-1.19 servers.

`modifier` is not strictly a 1.19 addition, but bfb had no way to create an IDF sparse vector at all, which made the new IDF search parameter unreachable. Added so the feature is usable end-to-end.

## Search config

- **`idf_corpus`** on sparse requests — IDF statistics are computed over the points matching these conditions instead of the whole collection (the multi-tenant case). Reuses the existing `FilterPayloadConfig` shape, so the corpus filter is regenerated per query.
- **`match_prefix: <chars>`** on keyword filters — matches a generated value truncated to N characters, so prefix length is the selectivity knob. Requires the field's index to be created with `prefix: true`.

## Legacy flags

`--memory-payload`, `--memory-payload-index`, `--memory-index`, `--memory-vectors`, `--memory-quantization`, `--sparse-idf`, `--search-idf-corpus`, and `Turbo4` accepted by `--datatype`.

## Client-side changes this required

- `SearchParams` is no longer `Copy` (it now holds a `Filter`).
- The exact-search quality reference now flips only `exact` on each query's existing params instead of overwriting them wholesale — otherwise the reference query would drop its IDF corpus and the recall comparison would be against a different request.
- `--search-idf-corpus` applies only to sparse queries; the server rejects `idf` on a dense vector.
- `build_quantization_config` is now shared with the flag-driven path, replacing a duplicated 65-line match.

## Verification

`cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace` (108 tests) all pass.

Smoke-tested end-to-end against a throwaway Qdrant — `bfb upload`, `bfb search`, `bfb scroll` with the updated examples, plus the legacy flag path with all five `--memory-*` flags and `--search-idf-corpus` in sparse-only and mixed dense+sparse modes. The last two bullets above are bugs that smoke test caught.

Two caveats worth knowing:

- The published `qdrant/qdrant:dev` image is still `1.18.3-dev`, so the 1.19-only fields are transmitted but ignored there. `idf` *is* validated by 1.18.3, which is how the dense-query rejection surfaced.
- The `dev` client crate still declares `version = "1.16.1-dev"`, so it prints a spurious "Client version 1.16.1-dev is not compatible with server version 1.18.3-dev" warning on every connection. That is upstream in the client, not something bfb can fix here.