### PR TITLE
feat(config): expose deleted_threshold and vacuum_min_vector_number

### DIFF
--- a/src/collection/from_config.rs
+++ b/src/collection/from_config.rs
@@ -294,6 +294,12 @@ pub async fn recreate_collection_from_config(
         if let Some(s) = opt.max_segment_size {
             optimizers_config = optimizers_config.max_segment_size(s);
         }
+        if let Some(t) = opt.deleted_threshold {
+            optimizers_config = optimizers_config.deleted_threshold(t);
+        }
+        if let Some(n) = opt.vacuum_min_vector_number {
+            optimizers_config = optimizers_config.vacuum_min_vector_number(n);
+        }
         if opt.prevent_unoptimized {
             optimizers_config = optimizers_config.prevent_unoptimized(true);
         }

--- a/src/config/collection.rs
+++ b/src/config/collection.rs
@@ -106,6 +106,12 @@ pub struct OptimizersConfig {
     pub indexing_threshold: Option<u64>,
     pub memmap_threshold: Option<u64>,
     pub max_segment_size: Option<u64>,
+    /// Fraction of a segment that must be deleted before the vacuum optimizer rebuilds it.
+    /// Qdrant's default is 0.2; lower it to make deletions heal promptly.
+    pub deleted_threshold: Option<f64>,
+    /// Minimum segment size (in vectors) for the vacuum optimizer to consider it at all.
+    /// Qdrant's default is 1000.
+    pub vacuum_min_vector_number: Option<u64>,
     #[serde(default)]
     pub prevent_unoptimized: bool,
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -60,6 +60,10 @@ collection:
     indexing_threshold: null     # uint64         optional
     memmap_threshold: null       # uint64         optional
     max_segment_size: null       # uint64         optional
+    deleted_threshold: null      # double         optional             fraction of a segment that must be
+                                 #   deleted before the vacuum optimizer rebuilds it (server default 0.2)
+    vacuum_min_vector_number: null # uint64       optional             smallest segment, in vectors, the
+                                 #   vacuum optimizer will consider (server default 1000)
     prevent_unoptimized: false   # bool           default=false        wait for a fully optimized collection
 
   # Collection-wide quantization (optional). Also settable per dense vector.
@@ -238,6 +242,8 @@ mod tests {
                     indexing_threshold: Some(20000),
                     memmap_threshold: Some(20000),
                     max_segment_size: Some(200000),
+                    deleted_threshold: Some(0.2),
+                    vacuum_min_vector_number: Some(1000),
                     prevent_unoptimized: false,
                 }),
                 quantization: Some(QuantizationConfig {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -60,7 +60,7 @@ collection:
     indexing_threshold: null     # uint64         optional
     memmap_threshold: null       # uint64         optional
     max_segment_size: null       # uint64         optional
-    deleted_threshold: null      # double         optional             fraction of a segment that must be
+    deleted_threshold: null      # float          optional             fraction of a segment that must be
                                  #   deleted before the vacuum optimizer rebuilds it (server default 0.2)
     vacuum_min_vector_number: null # uint64       optional             smallest segment, in vectors, the
                                  #   vacuum optimizer will consider (server default 1000)


### PR DESCRIPTION
Adds two optional fields to `collection.optimizers` in the upload config, passed through to Qdrant's `OptimizersConfigDiff`:
                                                                                                                                                                                                                                          
| Field | Type | Qdrant default | Meaning |
|---|---|---|---|               
| `deleted_threshold` | `f64` | `0.2` | Fraction of a segment that must be deleted before the vacuum optimizer rebuilds it |
| `vacuum_min_vector_number` | `u64` | `1000` | Smallest segment, in vectors, the vacuum optimizer will consider |

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?