### PR TITLE
feat: publish release binaries (musl + macOS) and add `bfb self-update`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+
+# Builds static Linux (musl) and macOS binaries and attaches them to a GitHub
+# release. Triggered by pushing a `v*` tag that matches the Cargo.toml version:
+#
+#   git tag v0.2.0 && git push origin v0.2.0
+#
+# `workflow_dispatch` runs the same build without publishing (binaries are kept
+# as workflow artifacts), which is handy for checking the build matrix.
+#
+# Asset names (`bfb-<target>.tar.gz` + `.sha256`) are a contract with
+# `bfb self-update` (`src/self_update.rs`) and the README install snippet.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check that the tag matches the Cargo.toml version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
+          if [ "$GITHUB_REF_NAME" != "v$version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match Cargo.toml version $version (expected tag v$version)"
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      # `cross` builds the musl targets inside a container that ships the musl
+      # C toolchain needed by ring / zstd-sys.
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build
+        run: |
+          ${{ matrix.cross && 'cross' || 'cargo' }} build --release --locked --target ${{ matrix.target }}
+
+      - name: Smoke test
+        # Only the binaries whose architecture matches the runner can be run.
+        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-apple-darwin'
+        run: |
+          target/${{ matrix.target }}/release/bfb --version
+          target/${{ matrix.target }}/release/bfb self-update --help > /dev/null
+
+      - name: Package
+        run: |
+          asset="bfb-${{ matrix.target }}.tar.gz"
+          tar -C "target/${{ matrix.target }}/release" -czf "$asset" bfb
+          shasum -a 256 "$asset" > "$asset.sha256"
+          cat "$asset.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bfb-${{ matrix.target }}
+          path: |
+            bfb-${{ matrix.target }}.tar.gz
+            bfb-${{ matrix.target }}.tar.gz.sha256
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - run: ls -l dist
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          # `v1.2.3-rc1`-style tags become pre-releases (`self-update` ignores
+          # those unless asked for by `--tag`, since it follows `releases/latest`).
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,29 +135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,11 +203,12 @@ dependencies = [
  "memmap2",
  "parquet",
  "qdrant-client",
- "rand 0.10.1",
+ "rand",
  "rand_distr",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tar",
  "tempfile",
  "tokio",
@@ -245,6 +223,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -319,8 +306,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core 0.10.1",
+ "cpufeatures 0.3.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -396,29 +383,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "console"
@@ -470,6 +438,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -491,6 +468,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "ctrlc"
@@ -570,6 +557,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,23 +577,6 @@ dependencies = [
  "libc",
  "objc2",
 ]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -695,21 +675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,16 +763,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -817,11 +790,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -833,7 +804,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -983,21 +954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,16 +972,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1058,88 +1011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,27 +1021,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "indexmap"
@@ -1205,22 +1055,6 @@ checksum = "63703cf9069b85dbe6fe26e1c5230d013dee99d3559cd3d02ba39e099ef7ab02"
 dependencies = [
  "indicatif",
  "log",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1269,55 +1103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,8 +1118,6 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1364,12 +1147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,12 +1160,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -1669,24 +1440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,11 +1498,9 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "futures",
- "futures-util",
  "parking_lot",
  "prost",
  "prost-types",
- "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -1767,62 +1518,6 @@ checksum = "300d1c86e9638eceb24568649d5ad0f31b949ff11ff1ffbacbe3e382a4dfee25"
 dependencies = [
  "sysinfo",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1848,42 +1543,13 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1899,7 +1565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.1",
+ "rand",
 ]
 
 [[package]]
@@ -1947,45 +1613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,21 +1624,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
 ]
 
 [[package]]
@@ -2033,7 +1645,6 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2061,36 +1672,8 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2098,7 +1681,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2115,15 +1697,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2232,6 +1805,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,22 +1836,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2298,12 +1866,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,20 +1893,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "sysinfo"
@@ -2432,31 +1980,6 @@ checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
-
-[[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2583,24 +2106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2160,12 @@ name = "twox-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2722,28 +2233,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2768,16 +2261,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"
@@ -2823,16 +2306,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2890,19 +2363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,16 +2375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,15 +2382,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2967,15 +2408,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3048,16 +2480,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3075,31 +2498,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3109,22 +2515,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3133,22 +2527,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3157,22 +2539,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3181,22 +2551,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -3287,12 +2645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3307,29 +2659,6 @@ name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
-
-[[package]]
-name = "yoke"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "zerocopy"
@@ -3352,64 +2681,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zlib-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,15 @@ parquet = { version = "59.1", default-features = false, features = [
     "lz4",
     "zstd",
 ] }
-qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "dev" }
+# `download_snapshots` (default) is unused and pulls reqwest + aws-lc-sys, which makes
+# static musl cross-builds needlessly painful; without it TLS is rustls + ring only.
+qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "dev", default-features = false, features = ["serde"] }
 rand = "0.10.1"
 rand_distr = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+sha2 = "0.10"
 tar = "0.4.44"
 tempfile = "3.25.0"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,3 +32,29 @@ docker run --privileged --rm tonistiigi/binfmt --install all
 docker run --platform=linux/arm64 --network=host qdrant/bfb:local /bfb # run bfb
 docker run --platform=linux/arm64 --network=host -it qdrant/bfb:local /bin/bash # shell
 ```
+
+## Releasing binaries
+
+`.github/workflows/release.yml` builds static Linux (`x86_64`/`aarch64`
+musl, via `cross`) and macOS (`aarch64`/`x86_64`) binaries and attaches them to
+a GitHub release as `bfb-<target>.tar.gz` + `.sha256`. Those names are relied on
+by `bfb self-update` (`src/self_update.rs`) and the README install snippet, so
+keep them stable.
+
+To cut a release:
+
+```sh
+# 1. bump `version` in Cargo.toml (and Cargo.lock), merge to dev
+# 2. tag the merged commit with a matching `v<version>` tag and push it
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+The workflow refuses tags that do not match the Cargo.toml version, since
+`self-update` compares the release tag against `CARGO_PKG_VERSION`. A tag with
+a `-` (e.g. `v0.2.0-rc1`) is published as a pre-release, which
+`releases/latest` — and therefore `self-update` — skips unless passed via
+`--tag`.
+
+Run the workflow manually (`workflow_dispatch`) to exercise the build matrix
+without publishing; the binaries are then available as workflow artifacts.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,65 @@
 
 Benchmarking tool for the [Qdrant](https://github.com/qdrant/qdrant) project
 
+## Installation
+
+### Prebuilt binaries
+
+Every [GitHub release](https://github.com/qdrant/bfb/releases) ships a
+single-file `bfb` binary for:
+
+| Platform              | Asset                                   |
+|-----------------------|-----------------------------------------|
+| Linux x86_64 (static) | `bfb-x86_64-unknown-linux-musl.tar.gz`  |
+| Linux aarch64 (static)| `bfb-aarch64-unknown-linux-musl.tar.gz` |
+| macOS Apple Silicon   | `bfb-aarch64-apple-darwin.tar.gz`       |
+| macOS Intel           | `bfb-x86_64-apple-darwin.tar.gz`        |
+
+The Linux binaries are statically linked against musl, so they run on any
+distribution without extra dependencies. To install the latest release into
+`/usr/local/bin`:
+
+```bash
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)   TARGET=x86_64-unknown-linux-musl ;;
+  Linux-aarch64)  TARGET=aarch64-unknown-linux-musl ;;
+  Darwin-arm64)   TARGET=aarch64-apple-darwin ;;
+  Darwin-x86_64)  TARGET=x86_64-apple-darwin ;;
+  *) echo "unsupported platform: $(uname -s)-$(uname -m)"; exit 1 ;;
+esac
+curl -sSfL "https://github.com/qdrant/bfb/releases/latest/download/bfb-$TARGET.tar.gz" | tar -xz
+sudo install -m 755 bfb /usr/local/bin/bfb && rm bfb
+bfb --version
+```
+
+Or pick a specific version by replacing `latest/download` with
+`download/v<version>`. Each asset has a matching `.sha256` file.
+
+### Upgrading
+
+An installed binary can upgrade itself to the latest release:
+
+```bash
+bfb self-update           # install the latest release (use sudo if /usr/local/bin is not writable)
+bfb self-update --check   # only report whether a newer release exists
+bfb self-update --tag v0.2.0   # install (or roll back to) a specific release
+```
+
+It downloads the asset for the current platform, verifies its checksum and
+atomically replaces the running executable.
+
+### Docker
+
+```bash
+docker run --rm --network=host qdrant/bfb:dev /bfb --help
+```
+
+### From source
+
+```bash
+cargo install --git https://github.com/qdrant/bfb --branch dev bfb
+```
+
 ## Usage
 
 ### `upload` — YAML-driven collection shape

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -524,6 +524,13 @@ pub enum Command {
     /// Print the upload-config file schema: every option, its type, default,
     /// and allowed values, as an annotated YAML reference.
     Schema,
+
+    /// Replace this binary with the latest GitHub release (or a chosen `--tag`).
+    ///
+    /// Downloads the prebuilt `bfb-<target>.tar.gz` for this platform from
+    /// https://github.com/qdrant/bfb/releases, verifies its checksum, and
+    /// atomically swaps it in place of the running executable.
+    SelfUpdate(crate::self_update::SelfUpdateArgs),
 }
 
 #[derive(clap::Args, Debug, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod results;
 mod save_jsonl;
 mod scroll;
 mod search;
+mod self_update;
 mod stats;
 mod upload;
 mod upsert;
@@ -112,8 +113,8 @@ async fn run_benchmark(args: Args, stopped: Arc<AtomicBool>) -> Result<()> {
         Some(Command::Search(search_args)) => return run_search(args, search_args, stopped).await,
         Some(Command::Upload(upload_args)) => return run_upload(args, upload_args, stopped).await,
         Some(Command::Scroll(scroll_args)) => return run_scroll(args, scroll_args, stopped).await,
-        // `Schema` is handled before the runtime starts; `None` falls through.
-        Some(Command::Schema) | None => {}
+        // `Schema` / `SelfUpdate` are handled before the runtime starts; `None` falls through.
+        Some(Command::Schema | Command::SelfUpdate(_)) | None => {}
     }
 
     if args.search_quality && args.search_exact {
@@ -176,10 +177,20 @@ fn parse_args() -> Args {
 fn main() {
     let args = parse_args();
 
-    // Pure print commands that need no network / Tokio runtime.
-    if let Some(Command::Schema) = args.command {
-        config::schema::print_schema();
-        return;
+    // Commands that need no Qdrant connection / Tokio runtime.
+    match &args.command {
+        Some(Command::Schema) => {
+            config::schema::print_schema();
+            return;
+        }
+        Some(Command::SelfUpdate(update_args)) => {
+            if let Err(err) = self_update::run(update_args) {
+                eprintln!("Error: {err:?}");
+                std::process::exit(1);
+            }
+            return;
+        }
+        _ => {}
     }
 
     let stopped = Arc::new(AtomicBool::new(false));

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,0 +1,375 @@
+//! `bfb self-update`: replace the running binary with a published GitHub release.
+//!
+//! Release assets are produced by `.github/workflows/release.yml` and named
+//! `bfb-<target>.tar.gz` (+ `.sha256`), where `<target>` is one of the
+//! [`SUPPORTED_TARGETS`]. The tarball holds a single `bfb` executable.
+//!
+//! The swap is a `rename(2)` of a fully written temp file over the current
+//! executable, so it is atomic and safe to do while this very process runs.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use flate2::read::GzDecoder;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use tar::Archive;
+
+/// GitHub repository releases are fetched from.
+pub const REPO: &str = "qdrant/bfb";
+
+/// Current binary version, as baked in by Cargo.
+pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Target triples the release workflow publishes binaries for.
+pub const SUPPORTED_TARGETS: &[&str] = &[
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+];
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct SelfUpdateArgs {
+    /// Only report whether a newer release is available; do not install it.
+    #[clap(long)]
+    pub check: bool,
+
+    /// Install this release tag (e.g. `v0.2.0`) instead of the latest one.
+    #[clap(long)]
+    pub tag: Option<String>,
+
+    /// Reinstall even when the selected release matches the running version.
+    #[clap(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct Release {
+    tag_name: String,
+    assets: Vec<Asset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Asset {
+    name: String,
+    browser_download_url: String,
+}
+
+pub fn run(args: &SelfUpdateArgs) -> Result<()> {
+    let release = fetch_release(args.tag.as_deref())?;
+    let release_version = release.tag_name.trim_start_matches('v');
+
+    if release_version == CURRENT_VERSION && !args.force {
+        println!(
+            "bfb {CURRENT_VERSION} is already the selected release ({})",
+            release.tag_name
+        );
+        return Ok(());
+    }
+
+    println!("Current version: {CURRENT_VERSION}");
+    println!(
+        "Release version: {} ({})",
+        release_version, release.tag_name
+    );
+    if args.check {
+        println!("Run `bfb self-update` to install it.");
+        return Ok(());
+    }
+
+    let target = current_target()?;
+    let asset_name = format!("bfb-{target}.tar.gz");
+    let asset = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == asset_name)
+        .with_context(|| {
+            format!(
+                "release {} has no asset `{asset_name}`; available: {}",
+                release.tag_name,
+                release
+                    .assets
+                    .iter()
+                    .map(|asset| asset.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+    let checksum_asset = release
+        .assets
+        .iter()
+        .find(|candidate| candidate.name == format!("{asset_name}.sha256"));
+
+    let exe = std::env::current_exe().context("failed to locate the running executable")?;
+    // `current_exe` can be a symlink (e.g. a `~/.local/bin/bfb -> …` install);
+    // replace the file it points to rather than the link.
+    let exe =
+        fs::canonicalize(&exe).with_context(|| format!("failed to resolve {}", exe.display()))?;
+    let install_dir = exe
+        .parent()
+        .with_context(|| format!("{} has no parent directory", exe.display()))?;
+
+    println!("Downloading {}...", asset.browser_download_url);
+    let tarball = download(&asset.browser_download_url)?;
+
+    if let Some(checksum_asset) = checksum_asset {
+        let expected = download(&checksum_asset.browser_download_url)?;
+        verify_sha256(&tarball, &expected, &asset_name)?;
+    } else {
+        println!("Warning: release has no `{asset_name}.sha256`; skipping checksum verification");
+    }
+
+    let binary = extract_binary(&tarball, &asset_name)?;
+
+    // Write next to the target so the final rename stays on one filesystem, and
+    // never truncate the running executable in place (that crashes the process).
+    let staged = stage_binary(install_dir, &binary).with_context(|| {
+        format!(
+            "failed to write the new binary into {} (try re-running with `sudo` if the \
+             directory is not writable)",
+            install_dir.display()
+        )
+    })?;
+    fs::rename(&staged, &exe).map_err(|err| {
+        let _ = fs::remove_file(&staged);
+        anyhow::anyhow!(
+            "failed to replace {} (try re-running with `sudo` if the file is not writable): {err}",
+            exe.display()
+        )
+    })?;
+
+    println!(
+        "Updated {} to bfb {release_version} ({}).",
+        exe.display(),
+        release.tag_name
+    );
+    Ok(())
+}
+
+/// Map the running platform onto a published release target. Linux always maps
+/// to the static musl build, so a `-gnu`-compiled dev binary still updates.
+fn current_target() -> Result<&'static str> {
+    let target = match (std::env::consts::ARCH, std::env::consts::OS) {
+        ("x86_64", "linux") => "x86_64-unknown-linux-musl",
+        ("aarch64", "linux") => "aarch64-unknown-linux-musl",
+        ("x86_64", "macos") => "x86_64-apple-darwin",
+        ("aarch64", "macos") => "aarch64-apple-darwin",
+        (arch, os) => bail!(
+            "no prebuilt bfb binaries are published for {arch}-{os}; supported targets: {}",
+            SUPPORTED_TARGETS.join(", ")
+        ),
+    };
+    Ok(target)
+}
+
+/// GitHub REST API base. `GITHUB_API_URL` is the conventional override (it is
+/// set in GitHub Actions and used for GitHub Enterprise hosts).
+fn api_base() -> String {
+    std::env::var("GITHUB_API_URL")
+        .ok()
+        .filter(|url| !url.is_empty())
+        .map(|url| url.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| "https://api.github.com".to_string())
+}
+
+fn fetch_release(tag: Option<&str>) -> Result<Release> {
+    let api = api_base();
+    let url = match tag {
+        Some(tag) => format!("{api}/repos/{REPO}/releases/tags/{tag}"),
+        None => format!("{api}/repos/{REPO}/releases/latest"),
+    };
+    let body = download(&url).with_context(|| match tag {
+        Some(tag) => format!("failed to fetch release `{tag}` of {REPO}"),
+        None => format!("failed to fetch the latest release of {REPO}"),
+    })?;
+    serde_json::from_slice(&body).context("failed to parse the GitHub release response")
+}
+
+/// GET `url` and return the body. Follows redirects (release assets redirect to
+/// a CDN). Honours `GITHUB_TOKEN` to lift the anonymous API rate limit.
+fn download(url: &str) -> Result<Vec<u8>> {
+    let mut request = ureq::get(url)
+        .header("User-Agent", format!("bfb/{CURRENT_VERSION}"))
+        .header(
+            "Accept",
+            "application/vnd.github+json, application/octet-stream",
+        );
+    if url.starts_with(&api_base())
+        && let Ok(token) = std::env::var("GITHUB_TOKEN")
+        && !token.is_empty()
+    {
+        request = request.header("Authorization", format!("Bearer {token}"));
+    }
+    let response = request
+        .call()
+        .with_context(|| format!("request to {url} failed"))?;
+    let mut body = Vec::new();
+    response
+        .into_body()
+        .into_reader()
+        .read_to_end(&mut body)
+        .with_context(|| format!("failed to read response body of {url}"))?;
+    Ok(body)
+}
+
+/// `expected` is the content of a `sha256sum`-style file: `<hex>  <name>`.
+fn verify_sha256(data: &[u8], expected: &[u8], asset_name: &str) -> Result<()> {
+    let expected = std::str::from_utf8(expected)
+        .context("checksum file is not UTF-8")?
+        .split_whitespace()
+        .next()
+        .context("checksum file is empty")?
+        .to_ascii_lowercase();
+    let actual = format!("{:x}", Sha256::digest(data));
+    if actual != expected {
+        bail!("checksum mismatch for {asset_name}: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+/// Pull the single `bfb` executable out of a `.tar.gz` release asset.
+fn extract_binary(tarball: &[u8], asset_name: &str) -> Result<Vec<u8>> {
+    let mut archive = Archive::new(GzDecoder::new(tarball));
+    for entry in archive
+        .entries()
+        .with_context(|| format!("{asset_name} is not a valid tar.gz archive"))?
+    {
+        let mut entry =
+            entry.with_context(|| format!("failed to read an entry of {asset_name}"))?;
+        let path = entry.path()?.into_owned();
+        if path.file_name().is_some_and(|name| name == "bfb")
+            && entry.header().entry_type().is_file()
+        {
+            let mut binary = Vec::new();
+            entry
+                .read_to_end(&mut binary)
+                .with_context(|| format!("failed to read `bfb` from {asset_name}"))?;
+            return Ok(binary);
+        }
+    }
+    bail!("{asset_name} does not contain a `bfb` executable")
+}
+
+/// Write `binary` to a fresh, executable temp file inside `dir`.
+fn stage_binary(dir: &Path, binary: &[u8]) -> Result<PathBuf> {
+    let staged = dir.join(format!(".bfb-update-{}", std::process::id()));
+    let mut file = create_executable(&staged)?;
+    let written = (|| -> io::Result<()> {
+        file.write_all(binary)?;
+        file.sync_all()
+    })();
+    if let Err(err) = written {
+        let _ = fs::remove_file(&staged);
+        return Err(err).with_context(|| format!("failed to write {}", staged.display()));
+    }
+    Ok(staged)
+}
+
+#[cfg(unix)]
+fn create_executable(path: &Path) -> Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o755)
+        .open(path)
+        .with_context(|| format!("failed to create {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn create_executable(path: &Path) -> Result<File> {
+    File::create(path).with_context(|| format!("failed to create {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tarball_with(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(
+            Vec::new(),
+            flate2::Compression::fast(),
+        ));
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[test]
+    fn extracts_bfb_from_tarball() {
+        let tarball = tarball_with(&[("README.md", b"docs"), ("bfb", b"#!binary")]);
+        assert_eq!(extract_binary(&tarball, "x.tar.gz").unwrap(), b"#!binary");
+    }
+
+    #[test]
+    fn extracts_bfb_from_nested_dir() {
+        let tarball = tarball_with(&[("bfb-x86_64/bfb", b"nested")]);
+        assert_eq!(extract_binary(&tarball, "x.tar.gz").unwrap(), b"nested");
+    }
+
+    #[test]
+    fn rejects_tarball_without_binary() {
+        let tarball = tarball_with(&[("README.md", b"docs")]);
+        assert!(extract_binary(&tarball, "x.tar.gz").is_err());
+    }
+
+    #[test]
+    fn verifies_sha256sum_format() {
+        let data = b"hello";
+        let sum = format!("{:x}", Sha256::digest(data));
+        verify_sha256(
+            data,
+            format!("{sum}  bfb.tar.gz\n").as_bytes(),
+            "bfb.tar.gz",
+        )
+        .unwrap();
+        verify_sha256(data, sum.to_uppercase().as_bytes(), "bfb.tar.gz").unwrap();
+        assert!(verify_sha256(b"other", sum.as_bytes(), "bfb.tar.gz").is_err());
+        assert!(verify_sha256(data, b"", "bfb.tar.gz").is_err());
+    }
+
+    #[test]
+    fn parses_github_release_json() {
+        let json = r#"{"tag_name":"v0.2.0","name":"x","assets":[
+            {"name":"bfb-x86_64-unknown-linux-musl.tar.gz","browser_download_url":"https://e/a","size":1}
+        ]}"#;
+        let release: Release = serde_json::from_str(json).unwrap();
+        assert_eq!(release.tag_name, "v0.2.0");
+        assert_eq!(release.assets[0].browser_download_url, "https://e/a");
+    }
+
+    #[test]
+    fn staged_binary_is_executable_and_atomic_to_rename() {
+        let dir = tempfile::tempdir().unwrap();
+        let staged = stage_binary(dir.path(), b"bin").unwrap();
+        assert_eq!(fs::read(&staged).unwrap(), b"bin");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&staged).unwrap().permissions().mode() & 0o777,
+                0o755
+            );
+        }
+        let target = dir.path().join("bfb");
+        fs::write(&target, b"old").unwrap();
+        fs::rename(&staged, &target).unwrap();
+        assert_eq!(fs::read(&target).unwrap(), b"bin");
+    }
+
+    #[test]
+    fn current_platform_maps_to_a_published_target() {
+        // On unsupported dev platforms this is expected to error instead.
+        if let Ok(target) = current_target() {
+            assert!(SUPPORTED_TARGETS.contains(&target));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Release workflow** (`.github/workflows/release.yml`): on a `v*` tag, builds static Linux binaries (`x86_64`/`aarch64` musl, via `cross`) and macOS binaries (`aarch64`/`x86_64`), packages them as `bfb-<target>.tar.gz` + `.sha256`, and publishes a GitHub release with auto-generated notes. `workflow_dispatch` runs the same build matrix without publishing (artifacts only), for dry runs. The tag must match the `Cargo.toml` version, otherwise the build fails.
- **Dependency trim**: `qdrant-client` now uses `default-features = false, features = ["serde"]`. The unused `download_snapshots` feature pulled `reqwest` → `aws-lc-sys`, which is the usual blocker for musl cross-builds (needs cmake / target C toolchains). TLS is now rustls + ring only; `Cargo.lock` loses ~800 lines.
- **`bfb self-update`** (`src/self_update.rs`): `bfb self-update [--check] [--tag vX.Y.Z] [--force]` fetches the release from the GitHub API (honours `GITHUB_TOKEN` / `GITHUB_API_URL`), downloads the asset for the current platform (Linux always maps to the musl build), verifies the sha256, extracts `bfb`, and atomically `rename`s it over the running executable (symlink-aware, with "try sudo" hints).
- **Docs**: README gets an *Installation* section (asset table, platform-detecting `curl | tar` snippet, pinning a version, self-update, Docker, `cargo install`); DEVELOPMENT.md documents the release procedure.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` (150 tests, incl. 7 new for self-update)
- [x] `cargo build --release --target x86_64-unknown-linux-musl` locally → statically linked, runs
- [x] End-to-end `self-update` against a local mock of the GitHub API: update, `--check`, same-version no-op, checksum mismatch (binary untouched), missing asset
- [ ] Trigger `Release` via `workflow_dispatch` on this branch to verify the aarch64-musl (`cross`) and macOS legs on real runners
- [ ] After merge: `git tag v0.1.1 && git push origin v0.1.1` to cut the first release

## Notes

- Docker in the README points at `qdrant/bfb:dev`; `:latest` on Docker Hub is from 2024 (only pushed from a `main` branch that doesn't exist).
- Possible follow-ups: musl build check in `ci.yml`; `strip = true` in the release profile to shrink downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
