### PR TITLE
Print the effective configuration at startup

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -280,6 +280,39 @@ fn default_custom() -> String {
 mod tests {
     use super::*;
 
+    /// `bfb` echoes the parsed config back to the console, which serializes it.
+    /// A dataset source flattens an inline dataset definition into an
+    /// internally-tagged enum variant — the one shape serde can refuse to
+    /// serialize — so keep a config that uses it round-trippable.
+    #[test]
+    fn effective_config_renders_back_to_yaml() {
+        let yaml = r#"
+collection:
+  name: glove
+  vectors:
+    - size: 25
+      distance: cosine
+      source:
+        type: dataset
+        name: glove-25-angular
+        format: h5
+        path: glove-25-angular/glove-25-angular.hdf5
+  fields:
+    - name: a
+      type: keyword
+"#;
+        let cfg: UploadConfig = serde_yaml::from_str(yaml).unwrap();
+        cfg.validate().unwrap();
+
+        let rendered = serde_yaml::to_string(&cfg).expect("config must be printable");
+        assert!(rendered.contains("glove-25-angular"), "{rendered}");
+        // Defaults are materialized, which is the point of printing it.
+        assert!(rendered.contains("datatype: float32"), "{rendered}");
+
+        let reparsed: UploadConfig = serde_yaml::from_str(&rendered).unwrap();
+        reparsed.validate().unwrap();
+    }
+
     #[test]
     fn parses_minimal_config() {
         let yaml = r#"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use tokio::runtime;
 
 use args::{Args, Command};
 use config::examples::ExampleKind;
-use results::{BenchmarkResults, IndexPhase};
+use results::{BenchmarkResults, IndexPhase, RunConfig};
 
 mod args;
 mod client;
@@ -26,6 +26,31 @@ mod self_update;
 mod stats;
 mod upload;
 mod upsert;
+
+/// Echo what the run actually resolved to: the CLI knobs plus the parsed YAML,
+/// with every default materialized. A benchmark log is then self-describing —
+/// it records the configuration that ran, not the path of a generated file that
+/// no longer exists by the time anyone reads the log.
+fn print_effective_config<T: serde::Serialize>(run: &RunConfig, config: &T) {
+    println!("--- Effective configuration ---");
+    for (label, rendered) in [
+        ("run", serde_yaml::to_string(run)),
+        ("config", serde_yaml::to_string(config)),
+    ] {
+        match rendered {
+            // Indent the block so the whole section is one parseable YAML
+            // document that can be pasted straight back into a config file.
+            Ok(yaml) => {
+                println!("{label}:");
+                for line in yaml.lines() {
+                    println!("  {line}");
+                }
+            }
+            Err(err) => println!("{label}: <failed to render: {err}>"),
+        }
+    }
+    println!("--- End effective configuration ---");
+}
 
 /// Wait for the index and record how long it took.
 async fn run_wait_index(args: &Args, stopped: Arc<AtomicBool>) -> Result<IndexPhase> {
@@ -52,6 +77,7 @@ async fn run_scroll(
     args.collection_name = config.collection.name.clone();
 
     let mut results = BenchmarkResults::new(&args, Some(resolved.origin));
+    print_effective_config(&results.config, &config);
     results.results.scroll = Some(query::scroll_with_config(&args, &config, stopped).await?);
     results.write_if_requested(&args)
 }
@@ -77,6 +103,7 @@ async fn run_search(
     }
 
     let mut results = BenchmarkResults::new(&args, Some(resolved.origin));
+    print_effective_config(&results.config, &config);
     results.results.search = Some(query::search_with_config(&args, &config, stopped).await?);
     results.write_if_requested(&args)
 }
@@ -107,6 +134,7 @@ async fn run_upload(
     }
 
     let mut results = BenchmarkResults::new(&args, Some(resolved.origin));
+    print_effective_config(&results.config, &config);
 
     if !args.skip_create && !args.skip_setup {
         collection::recreate_collection_from_config(&config, &args, stopped.clone()).await?;


### PR DESCRIPTION
## Problem

`bfb upload / search / scroll --file` logged nothing about what the run actually resolved to. The console showed the *path* of a config file — which, for a generated config, is a temp file that no longer exists by the time anyone reads the log — and nothing at all about the CLI knobs (`-n`, `-p`, `-t`, `--batch-size`).

## Change

Echo both back as YAML before the run starts, with every default materialized:

```
--- Effective configuration ---
run:
  bfb_version: 1.13.0
  collection_name: cfgtest
  num_vectors: 10
  batch_size: 100
  parallel: 2
  threads: 2
  config_file: /tmp/cfgtest-upload.yaml
config:
  collection:
    name: cfgtest
    id: integer
    on_disk_payload: true
    ...
    vectors:
    - name: null
      size: 8
      distance: cosine
      datatype: float32
      ...
--- End effective configuration ---
```

The blocks are indented so the whole section parses as one YAML document and can be pasted straight back into a config file.

Applies to all three config-driven commands (`upload`, `search`, `scroll`). The legacy flag-driven path is unchanged — its configuration *is* the command line.

## Test

`config::tests::effective_config_renders_back_to_yaml` parses a config that uses a dataset source, serializes it, and re-parses the result. A dataset source flattens an inline dataset definition into an internally-tagged enum variant — the one shape serde can refuse to serialize — so it is worth pinning.

Verified by hand against a live Qdrant on both the `upload` and `search` paths; full test suite passes (155 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)